### PR TITLE
fix(build): still running from dist folder

### DIFF
--- a/scripts/ci/after-success.sh
+++ b/scripts/ci/after-success.sh
@@ -2,7 +2,7 @@
 # Script which always runs when the current Travis mode succeeds.
 
 # Go to the project root directory
-cd $(dirname $0)/../../dist
+cd $(dirname $0)/../..
 
 # If not running as a PR
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then


### PR DESCRIPTION
Do not run semantic-release from dist folder