### PR TITLE
fix: better panning in zoomed-in-mode + remove speed-criteria from zoomed-mode when calculating next page

### DIFF
--- a/src/lib/src/core/models/viewer-options.ts
+++ b/src/lib/src/core/models/viewer-options.ts
@@ -9,10 +9,10 @@ export const ViewerOptions = {
   },
 
   pan: {
-    // Sensitivity when determining zoomed-in-swipe-direction.
+    // Sensitivity when determining swipe-direction.
     // Higher threshold means that swipe must be more focused in
     // x-direction before the gesture is recognized as "left" or "right"
-    swipeDirectionZoomedThreshold: 70
+    swipeDirectionThreshold: 70
   },
 
   // All transition times in milliseconds

--- a/src/lib/src/core/viewer-service/page-zoomed-mode-calculate-next-page-strategy.spec.ts
+++ b/src/lib/src/core/viewer-service/page-zoomed-mode-calculate-next-page-strategy.spec.ts
@@ -8,21 +8,8 @@ describe('PageZoomedModeCalculateNextPageStrategy ', () => {
     strategy = new PageZoomedModeCalculateNextPageStrategy();
   });
 
-
-  it('should stay on same page when speed is below 50', () => {
+  it('should stay on same page when pageEndHitCountReached is false', () => {
     const res = strategy.calculateNextPage({
-      speed: 45,
-      direction: Direction.LEFT,
-      currentPageIndex: 1,
-      pageEndHitCountReached: true
-    });
-
-    expect(res).toBe(1);
-  });
-
-  it('should stay on same page when forceNextPage is false', () => {
-    const res = strategy.calculateNextPage({
-      speed: 200,
       direction: Direction.LEFT,
       currentPageIndex: 1,
       pageEndHitCountReached: false
@@ -31,9 +18,8 @@ describe('PageZoomedModeCalculateNextPageStrategy ', () => {
     expect(res).toBe(1);
   });
 
-  it('should get next page if speed is 50 and direction is left', () => {
+  it('should get next page if direction is left and hitcount is reached', () => {
     const res = strategy.calculateNextPage({
-      speed: 50,
       direction: Direction.LEFT,
       currentPageIndex: 1,
       pageEndHitCountReached: true
@@ -42,9 +28,8 @@ describe('PageZoomedModeCalculateNextPageStrategy ', () => {
     expect(res).toBe(2);
   });
 
-  it('should get previous page if speed is 50 and direction is right', () => {
+  it('should get previous page if direction is right and hitcount is reached', () => {
     const res = strategy.calculateNextPage({
-      speed: 50,
       direction: Direction.RIGHT,
       currentPageIndex: 2,
       pageEndHitCountReached: true

--- a/src/lib/src/core/viewer-service/page-zoomed-mode-calculate-next-page-strategy.ts
+++ b/src/lib/src/core/viewer-service/page-zoomed-mode-calculate-next-page-strategy.ts
@@ -11,7 +11,7 @@ export class PageZoomedModeCalculateNextPageStrategy implements CalculateNextPag
     const currentPageIndex = criteria.currentPageIndex;
     const pageEndHitCountReached = criteria.pageEndHitCountReached;
 
-    let nextPage = (pageEndHitCountReached && speed >= 50) ? 1 : 0;
+    let nextPage = (pageEndHitCountReached) ? 1 : 0;
 
     nextPage = direction === Direction.LEFT ? nextPage : nextPage * -1;
     nextPage = currentPageIndex + nextPage;

--- a/src/lib/src/core/viewer-service/page-zoomed-mode-calculate-next-page-strategy.ts
+++ b/src/lib/src/core/viewer-service/page-zoomed-mode-calculate-next-page-strategy.ts
@@ -6,7 +6,6 @@ import { CalculateNextPageStrategy, NextPageCriteria } from './calculate-next-pa
 export class PageZoomedModeCalculateNextPageStrategy implements CalculateNextPageStrategy {
 
   calculateNextPage(criteria: NextPageCriteria): number {
-    const speed = criteria.speed;
     const direction = criteria.direction;
     const currentPageIndex = criteria.currentPageIndex;
     const pageEndHitCountReached = criteria.pageEndHitCountReached;

--- a/src/lib/src/core/viewer-service/swipe-utils.spec.ts
+++ b/src/lib/src/core/viewer-service/swipe-utils.spec.ts
@@ -7,40 +7,40 @@ import { SwipeUtils } from './swipe-utils';
 
 describe('SwipeUtils ', () => {
 
-  const swipeDirectionZoomedThreshold = ViewerOptions.pan.swipeDirectionZoomedThreshold;
+  const swipeDirectionThreshold = ViewerOptions.pan.swipeDirectionThreshold;
 
-  it('should return right when swiping in PAGE-mode', () => {
+  it('should return right when swiping in without threshold', () => {
     const start: Point = { x: 0, y: 50 };
     const end: Point = { x: 100, y: 50 };
-    const direction = SwipeUtils.getSwipeDirection(ViewerMode.PAGE, start, end);
+    const direction = SwipeUtils.getSwipeDirection(start, end, false);
     expect(direction).toBe(Direction.RIGHT);
   });
 
-  it('should return left when swiping in PAGE-mode', () => {
+  it('should return left when swiping without threshold', () => {
     const start: Point = { x: 100, y: 50 };
     const end: Point = { x: 0, y: 50 };
-    const direction = SwipeUtils.getSwipeDirection(ViewerMode.PAGE, start, end);
+    const direction = SwipeUtils.getSwipeDirection(start, end, false);
     expect(direction).toBe(Direction.LEFT);
   });
 
-  it('should return left on zoomed-in-swipe', () => {
-    const start: Point = { x: swipeDirectionZoomedThreshold + 1, y: 50 };
+  it('should return left when swiping with threshold', () => {
+    const start: Point = { x: swipeDirectionThreshold + 1, y: 50 };
     const end: Point = { x: 0, y: 50 };
-    const direction = SwipeUtils.getSwipeDirection(ViewerMode.PAGE_ZOOMED, start, end);
+    const direction = SwipeUtils.getSwipeDirection(start, end, true);
     expect(direction).toBe(Direction.LEFT);
   });
 
-  it('should return right on zoomed-in-swipe', () => {
+  it('should return right when swiping with threshold', () => {
     const start: Point = { x: 0, y: 50 };
-    const end: Point = { x: swipeDirectionZoomedThreshold + 1, y: 50 };
-    const direction = SwipeUtils.getSwipeDirection(ViewerMode.PAGE_ZOOMED, start, end);
+    const end: Point = { x: swipeDirectionThreshold + 1, y: 50 };
+    const direction = SwipeUtils.getSwipeDirection(start, end, true);
     expect(direction).toBe(Direction.RIGHT);
   });
 
-  it('should return undefined on zoomed-in-swipe when deltaY is higher than deltaX (not implemented)', () => {
+  it('should return undefined with threshold when deltaY is higher than deltaX (not implemented)', () => {
     const start: Point = { x: 0, y: 50 };
     const end: Point = { x: 0, y: 0 };
-    const direction = SwipeUtils.getSwipeDirection(ViewerMode.PAGE_ZOOMED, start, end);
+    const direction = SwipeUtils.getSwipeDirection(start, end, true);
     expect(direction).toBe(undefined);
   });
 

--- a/src/lib/src/core/viewer-service/swipe-utils.ts
+++ b/src/lib/src/core/viewer-service/swipe-utils.ts
@@ -1,4 +1,3 @@
-import { ViewerMode } from '../models/viewer-mode';
 import { Point } from '../models/point';
 import { Side } from '../models/side';
 import { Direction } from '../models/direction';
@@ -8,10 +7,10 @@ export class SwipeUtils {
 
 
   // Added threshold to prevent sensitive direction-calculation when zoomed in
-  static getSwipeDirection(mode: ViewerMode, start: Point, end: Point): Direction {
+  static getSwipeDirection(start: Point, end: Point, useThreshold?: boolean): Direction {
     let deltaX = Math.abs(start.x - end.x);
     const deltaY = Math.abs(start.y - end.y);
-    deltaX = (mode === ViewerMode.PAGE_ZOOMED) ? deltaX - ViewerOptions.pan.swipeDirectionZoomedThreshold : deltaX;
+    deltaX = (useThreshold) ? deltaX - ViewerOptions.pan.swipeDirectionThreshold : deltaX;
 
     if (start.x > end.x && (deltaX >= deltaY)) {
       return Direction.LEFT;

--- a/src/lib/src/core/viewer-service/viewer.service.ts
+++ b/src/lib/src/core/viewer-service/viewer.service.ts
@@ -574,7 +574,7 @@ export class ViewerService implements OnInit {
       const pageBounds: Bounds = this.getPageBounds(this.pageService.currentPage);
       const vpBounds: Bounds = this.getViewportBounds();
       const pannedPastSide: Side = SwipeUtils.getSideIfPanningPastEndOfPage(pageBounds, vpBounds);
-      const direction: Direction = SwipeUtils.getSwipeDirection(ViewerMode.PAGE_ZOOMED, this.dragStartPosition, dragEndPosision);
+      const direction: Direction = SwipeUtils.getSwipeDirection(this.dragStartPosition, dragEndPosision, false);
       if (
         (pannedPastSide === Side.LEFT && direction === Direction.RIGHT) ||
         (pannedPastSide === Side.RIGHT && direction === Direction.LEFT)
@@ -589,10 +589,12 @@ export class ViewerService implements OnInit {
     const speed: number = e.speed;
     const dragEndPosision = e.position;
 
+    const isPageZoomed = this.modeService.mode === ViewerMode.PAGE_ZOOMED;
+
     const pageBounds: Bounds = this.getPageBounds(this.pageService.currentPage);
     const viewportBounds: Bounds = this.getViewportBounds();
 
-    const direction: Direction = SwipeUtils.getSwipeDirection(this.modeService.mode, this.dragStartPosition, dragEndPosision);
+    const direction: Direction = SwipeUtils.getSwipeDirection(this.dragStartPosition, dragEndPosision, isPageZoomed);
     const viewportCenter: Point = this.getViewportCenter();
 
     const currentPageIndex: number = this.pageService.currentPage;


### PR DESCRIPTION
- Better panning in zoomed-in-mode; Stop viewport from panning slightly outside sides of pages
- Remove speed-criteria from zoomed-in-mode: This criteria isn't necessary in my opinion, and also doesn't exist on Play Books