### PR TITLE
fix: NGXMIM-33 - viewport doesn't pan on first/last page

### DIFF
--- a/src/lib/src/core/models/options.ts
+++ b/src/lib/src/core/models/options.ts
@@ -30,7 +30,7 @@ export class Options {
   homeFillsViewer = false;
   panHorizontal = true;
   panVertical = false;
-  constrainDuringPan = true;
+  constrainDuringPan = false;
   wrapHorizontal = false;
   wrapVertical = false;
   minZoomImageRatio = 1;


### PR DESCRIPTION
Setting constrainDuringPan to false seems to be the easiest fix for this issue. Now the page first/last pages bounces back when it hits the edges