### PR TITLE
fix: NGXMIM-34 - Panning does not stop when hitting the edge of the page if panning diagonal

### DIFF
--- a/src/lib/src/core/viewer-service/swipe-utils.spec.ts
+++ b/src/lib/src/core/viewer-service/swipe-utils.spec.ts
@@ -106,10 +106,7 @@ describe('SwipeUtils ', () => {
   });
 
   it('should return false when direction is not inside right semicircle (equivalent to left semicircle)', () => {
-    let direction = -Math.PI / 4;
-    expect(SwipeUtils.isDirectionInRightSemicircle(direction)).toBe(false);
-
-    direction = -Math.PI / 8;
+    const direction = -Math.PI / 1.5;
     expect(SwipeUtils.isDirectionInRightSemicircle(direction)).toBe(false);
   });
 

--- a/src/lib/src/core/viewer-service/swipe-utils.spec.ts
+++ b/src/lib/src/core/viewer-service/swipe-utils.spec.ts
@@ -97,4 +97,20 @@ describe('SwipeUtils ', () => {
     expect(SwipeUtils.isPanningPastCenter(pageBounds, center)).toBe(false);
   });
 
+  it('should return true when direction is inside right semicircle', () => {
+    let direction = Math.PI / 4;
+    expect(SwipeUtils.isDirectionInRightSemicircle(direction)).toBe(true);
+
+    direction = Math.PI / 8;
+    expect(SwipeUtils.isDirectionInRightSemicircle(direction)).toBe(true);
+  });
+
+  it('should return false when direction is not inside right semicircle (equivalent to left semicircle)', () => {
+    let direction = -Math.PI / 4;
+    expect(SwipeUtils.isDirectionInRightSemicircle(direction)).toBe(false);
+
+    direction = -Math.PI / 8;
+    expect(SwipeUtils.isDirectionInRightSemicircle(direction)).toBe(false);
+  });
+
 });

--- a/src/lib/src/core/viewer-service/swipe-utils.ts
+++ b/src/lib/src/core/viewer-service/swipe-utils.ts
@@ -44,4 +44,14 @@ export class SwipeUtils {
     const isPastCenterLeft = pageBounds.x > vpCenter.x;
     return isPastCenterRight || isPastCenterLeft;
   }
+
+  /**
+   *
+   * @param {direction} direction Current computed direction, expressed as an
+   * angle counterclockwise relative to the positive X axis (-pi to pi, in radians).
+   * Only valid if speed > 0.
+   */
+  static isDirectionInRightSemicircle(direction: number) {
+    return direction > -Math.PI / 2 && direction < Math.PI / 2;
+  }
 }

--- a/src/lib/src/core/viewer-service/viewer.service.ts
+++ b/src/lib/src/core/viewer-service/viewer.service.ts
@@ -638,6 +638,8 @@ export class ViewerService {
     return this.viewer.viewport.getCenter(true);
   }
 
+
+
   private dragHandler = (e: any) => {
     this.viewer.panHorizontal = true;
     if (this.modeService.mode === ViewerMode.PAGE_ZOOMED) {
@@ -645,10 +647,10 @@ export class ViewerService {
       const pageBounds: Bounds = this.getPageBounds(this.pageService.currentPage);
       const vpBounds: Bounds = this.getViewportBounds();
       const pannedPastSide: Side = SwipeUtils.getSideIfPanningPastEndOfPage(pageBounds, vpBounds);
-      const direction: Direction = SwipeUtils.getSwipeDirection(this.dragStartPosition, dragEndPosision, false);
+      const direction: number = e.direction;
       if (
-        (pannedPastSide === Side.LEFT && direction === Direction.RIGHT) ||
-        (pannedPastSide === Side.RIGHT && direction === Direction.LEFT)
+        (pannedPastSide === Side.LEFT && SwipeUtils.isDirectionInRightSemicircle(direction)) ||
+        (pannedPastSide === Side.RIGHT && !SwipeUtils.isDirectionInRightSemicircle(direction))
       ) {
         this.viewer.panHorizontal = false;
       }


### PR DESCRIPTION
Added calculation for direction inside right / left semicircle to stop the viewer from panning horizontally past the edges