### PR TITLE
fix: cleanup viewer on destroy

### DIFF
--- a/src/lib/src/attribution-dialog/attribution-dialog.service.ts
+++ b/src/lib/src/attribution-dialog/attribution-dialog.service.ts
@@ -41,15 +41,11 @@ export class AttributionDialogService {
     }));
   }
 
-  public cleanUp() {
+  public destroy() {
     this.close();
     if (this.dialogSubscription) {
       this.dialogSubscription.unsubscribe();
     }
-  }
-
-  public destroy() {
-    this.cleanUp();
     this.subscriptions.forEach((subscription: Subscription) => {
       subscription.unsubscribe();
     });

--- a/src/lib/src/attribution-dialog/attribution-dialog.service.ts
+++ b/src/lib/src/attribution-dialog/attribution-dialog.service.ts
@@ -16,7 +16,6 @@ export class AttributionDialogService {
   private _el: ElementRef;
   private attributionDialogHeight = 0;
   private subscriptions: Array<Subscription> = [];
-  private dialogSubscription: Subscription;
 
   constructor(
     private dialog: MdDialog,
@@ -43,9 +42,6 @@ export class AttributionDialogService {
 
   public destroy() {
     this.close();
-    if (this.dialogSubscription) {
-      this.dialogSubscription.unsubscribe();
-    }
     this.subscriptions.forEach((subscription: Subscription) => {
       subscription.unsubscribe();
     });
@@ -61,7 +57,7 @@ export class AttributionDialogService {
        * Sleeping for material animations to finish
        * fix: https://github.com/angular/material2/issues/7438
        */
-      this.dialogSubscription = Observable
+      this.subscriptions.push(Observable
         .interval(1000)
         .take(1)
         .subscribe(() => {
@@ -72,7 +68,7 @@ export class AttributionDialogService {
           });
           this.isAttributionDialogOpen = true;
           this.closeDialogAfter(timeout);
-        });
+        }));
     }
   }
 

--- a/src/lib/src/content-search-dialog/content-search-dialog.service.ts
+++ b/src/lib/src/content-search-dialog/content-search-dialog.service.ts
@@ -32,15 +32,11 @@ export class ContentSearchDialogService {
     }));
   }
 
-  public cleanUp() {
+  public destroy() {
     this.close();
     if (this.dialogSubscription) {
       this.dialogSubscription.unsubscribe();
     }
-  }
-
-  public destroy() {
-    this.cleanUp();
     this.subscriptions.forEach((subscription: Subscription) => {
       subscription.unsubscribe();
     });

--- a/src/lib/src/content-search-dialog/content-search-dialog.service.ts
+++ b/src/lib/src/content-search-dialog/content-search-dialog.service.ts
@@ -14,22 +14,36 @@ export class ContentSearchDialogService {
   private _el: ElementRef;
   private isContentSearchDialogOpen = false;
   private dialogRef: MdDialogRef<ContentSearchDialogComponent>;
+  private subscriptions: Array<Subscription> = [];
+  private dialogSubscription: Subscription;
 
   constructor(
     private dialog: MdDialog,
     private contentSearchDialogConfigStrategyFactory: ContentSearchDialogConfigStrategyFactory,
-    private mimeResizeService: MimeResizeService) {
-      mimeResizeService.onResize.subscribe(rect => {
-        if (this.isContentSearchDialogOpen) {
-          const config = this.getDialogConfig();
-          this.dialogRef.updatePosition(config.position);
-          this.dialogRef.updateSize(config.width, config.height);
-        }
-      });
+    private mimeResizeService: MimeResizeService) { }
+
+  public initialize(): void {
+    this.subscriptions.push(this.mimeResizeService.onResize.subscribe(rect => {
+      if (this.isContentSearchDialogOpen) {
+        const config = this.getDialogConfig();
+        this.dialogRef.updatePosition(config.position);
+        this.dialogRef.updateSize(config.width, config.height);
+      }
+    }));
+  }
+
+  public cleanUp() {
+    this.close();
+    if (this.dialogSubscription) {
+      this.dialogSubscription.unsubscribe();
+    }
   }
 
   public destroy() {
-    this.close();
+    this.cleanUp();
+    this.subscriptions.forEach((subscription: Subscription) => {
+      subscription.unsubscribe();
+    });
   }
 
   set el(el: ElementRef) {

--- a/src/lib/src/content-search-dialog/content-search-dialog.service.ts
+++ b/src/lib/src/content-search-dialog/content-search-dialog.service.ts
@@ -15,7 +15,6 @@ export class ContentSearchDialogService {
   private isContentSearchDialogOpen = false;
   private dialogRef: MdDialogRef<ContentSearchDialogComponent>;
   private subscriptions: Array<Subscription> = [];
-  private dialogSubscription: Subscription;
 
   constructor(
     private dialog: MdDialog,
@@ -34,9 +33,6 @@ export class ContentSearchDialogService {
 
   public destroy() {
     this.close();
-    if (this.dialogSubscription) {
-      this.dialogSubscription.unsubscribe();
-    }
     this.subscriptions.forEach((subscription: Subscription) => {
       subscription.unsubscribe();
     });

--- a/src/lib/src/contents-dialog/contents-dialog.service.ts
+++ b/src/lib/src/contents-dialog/contents-dialog.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, ElementRef } from '@angular/core';
 import { MdDialog, MdDialogConfig, MdDialogRef } from '@angular/material';
+import { Subscription } from 'rxjs/Subscription';
 
 import { ContentsDialogComponent } from './contents-dialog.component';
 import { ContentsDialogConfigStrategyFactory } from './contents-dialog-config-strategy-factory';
@@ -10,22 +11,37 @@ export class ContentsDialogService {
   private _el: ElementRef;
   private isContentsDialogOpen = false;
   private dialogRef: MdDialogRef<ContentsDialogComponent>;
+  private subscriptions: Array<Subscription> = [];
+  private dialogSubscription: Subscription;
 
   constructor(
     private dialog: MdDialog,
     private contentsDialogConfigStrategyFactory: ContentsDialogConfigStrategyFactory,
     private mimeResizeService: MimeResizeService) {
-      mimeResizeService.onResize.subscribe(rect => {
-        if (this.isContentsDialogOpen) {
-          const config = this.getDialogConfig();
-          this.dialogRef.updatePosition(config.position);
-          this.dialogRef.updateSize(config.width, config.height);
-        }
-      });
+  }
+
+  public initialize(): void {
+    this.subscriptions.push(this.mimeResizeService.onResize.subscribe(rect => {
+      if (this.isContentsDialogOpen) {
+        const config = this.getDialogConfig();
+        this.dialogRef.updatePosition(config.position);
+        this.dialogRef.updateSize(config.width, config.height);
+      }
+    }));
+  }
+
+  public cleanUp() {
+    this.close();
+    if (this.dialogSubscription) {
+      this.dialogSubscription.unsubscribe();
+    }
   }
 
   public destroy() {
-    this.close();
+    this.cleanUp();
+    this.subscriptions.forEach((subscription: Subscription) => {
+      subscription.unsubscribe();
+    });
   }
 
   set el(el: ElementRef) {

--- a/src/lib/src/contents-dialog/contents-dialog.service.ts
+++ b/src/lib/src/contents-dialog/contents-dialog.service.ts
@@ -30,15 +30,11 @@ export class ContentsDialogService {
     }));
   }
 
-  public cleanUp() {
+  public destroy() {
     this.close();
     if (this.dialogSubscription) {
       this.dialogSubscription.unsubscribe();
     }
-  }
-
-  public destroy() {
-    this.cleanUp();
     this.subscriptions.forEach((subscription: Subscription) => {
       subscription.unsubscribe();
     });

--- a/src/lib/src/contents-dialog/contents-dialog.service.ts
+++ b/src/lib/src/contents-dialog/contents-dialog.service.ts
@@ -12,7 +12,6 @@ export class ContentsDialogService {
   private isContentsDialogOpen = false;
   private dialogRef: MdDialogRef<ContentsDialogComponent>;
   private subscriptions: Array<Subscription> = [];
-  private dialogSubscription: Subscription;
 
   constructor(
     private dialog: MdDialog,
@@ -32,9 +31,6 @@ export class ContentsDialogService {
 
   public destroy() {
     this.close();
-    if (this.dialogSubscription) {
-      this.dialogSubscription.unsubscribe();
-    }
     this.subscriptions.forEach((subscription: Subscription) => {
       subscription.unsubscribe();
     });

--- a/src/lib/src/viewer/viewer.component.spec.ts
+++ b/src/lib/src/viewer/viewer.component.spec.ts
@@ -32,7 +32,7 @@ import '../rxjs-extension';
 
 describe('ViewerComponent', function () {
   const config: MimeViewerConfig = new MimeViewerConfig();
-  const osdAnimationTime = 2000;
+  const osdAnimationTime = 1500;
   let comp: ViewerComponent;
   let fixture: ComponentFixture<ViewerComponent>;
   let testHostComponent: TestHostComponent;
@@ -97,6 +97,182 @@ describe('ViewerComponent', function () {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
   });
 
+  it('should create component', () => expect(comp).toBeDefined());
+
+  it('should cleanUp when manifestUri changes', () => {
+    testHostComponent.manifestUri = 'dummyURI2';
+
+    spyOn(testHostComponent.viewerComponent, 'cleanUp').and.callThrough();
+    testHostFixture.detectChanges();
+
+    expect(testHostComponent.viewerComponent.cleanUp).toHaveBeenCalled();
+  });
+
+  it('should create viewer', () => {
+    expect(viewerService.getViewer()).toBeDefined();
+  });
+
+  it('should initially open in configs intial-mode', () => {
+    expect(modeService.mode).toBe(config.initViewerMode);
+  });
+
+  it('should change mode to initial-mode when changing manifest', (done) => {
+    viewerService.onOsdReadyChange.subscribe((state: boolean) => {
+      if (state) {
+        setTimeout(() => {
+          if (config.initViewerMode === ViewerMode.PAGE) {
+            modeService.mode = ViewerMode.DASHBOARD;
+            expect(modeService.mode).toBe(ViewerMode.DASHBOARD);
+          } else {
+            modeService.mode = ViewerMode.PAGE;
+            expect(modeService.mode).toBe(ViewerMode.PAGE);
+          }
+          testHostComponent.manifestUri = 'dummyURI3';
+          testHostFixture.detectChanges();
+          expect(modeService.mode).toBe(config.initViewerMode);
+          done();
+        }, osdAnimationTime);
+      }
+    });
+  });
+
+  it('should close all dialogs when manifestUri changes', () => {
+    testHostComponent.manifestUri = 'dummyURI2';
+
+    spyOn(testHostComponent.viewerComponent, 'cleanUp').and.callThrough();
+    testHostFixture.detectChanges();
+
+    expect(testHostComponent.viewerComponent.cleanUp).toHaveBeenCalled();
+  });
+
+  it('svgOverlay-plugin should be defined', () => {
+    expect(viewerService.getViewer().svgOverlay()).toBeDefined();
+  });
+
+  it('should create overlays', () => {
+    expect(viewerService.getOverlays()).toBeDefined();
+  });
+
+  it('should create overlays-array with same size as tilesources-array', () => {
+    expect(viewerService.getTilesources().length).toEqual(viewerService.getOverlays().length);
+  });
+
+  it('should return an OpenSeadragon.Rect with properties equal to overlay', () => {
+    let overlay = viewerService.getOverlays()[0];
+    let rect = viewerService.createRectangle(overlay);
+
+    expect(rect.x).toEqual(overlay.x.baseVal.value);
+    expect(rect.y).toEqual(overlay.y.baseVal.value);
+    expect(rect.width).toEqual(overlay.width.baseVal.value);
+    expect(rect.height).toEqual(overlay.height.baseVal.value);
+  });
+
+  it('should fit bounds to viewport for a page', (done: any) => {
+    const overlay = viewerService.getOverlays()[0];
+    const viewer = viewerService.getViewer();
+    const overlayBounds = viewerService.createRectangle(overlay);
+
+    viewerService.fitBounds(overlay);
+
+    setTimeout(() => {
+      const viewportX = Math.round(viewer.viewport.getBounds().x);
+      const viewportY = Math.round(viewer.viewport.getBounds().y);
+      const overlayX = Math.round(overlayBounds.y);
+      const overlayY = Math.round(overlayBounds.y);
+
+      expect((overlayY === viewportY) || (overlayX === viewportX)).toEqual(true);
+      done();
+    }, 0);
+
+  });
+
+  it('should return overlay-index if target is an overlay', () => {
+    let overlay, index;
+    overlay = viewerService.getOverlays()[0];
+    index = viewerService.getOverlayIndexFromClickEvent(overlay);
+    expect(index).toBe(0);
+
+    overlay = viewerService.getOverlays()[1];
+    index = viewerService.getOverlayIndexFromClickEvent(overlay);
+    expect(index).toBe(1);
+
+    overlay = viewerService.getOverlays()[12];
+    index = viewerService.getOverlayIndexFromClickEvent(overlay);
+    expect(index).toBe(12);
+
+    // Should return -1 for nonsense overlay
+    overlay = viewerService.getOverlays()[12000];
+    index = viewerService.getOverlayIndexFromClickEvent(overlay);
+    expect(index).toBe(-1);
+
+  });
+
+  it('should increase zoom level when pinching out', () => {
+    // comp.ngOnInit();
+    //
+    // pinchOut(viewerService);
+    //
+    // expect(viewerService.getZoom()).toBeGreaterThan(viewerService.getHomeZoom());
+    pending('Set to pending until we find a way to perform pinch event');
+  });
+
+  it('should decrease zoom level when is zoomed in and pinching in', () => {
+    // comp.ngOnInit();
+    // const previousZoom = 1;
+    // viewerService.zoomTo(previousZoom);
+    //
+    // pinchIn(viewerService);
+    //
+    // expect(viewerService.getZoom()).toBeLessThan(previousZoom);
+    pending('Set to pending until we find a way to perform pinch event');
+  });
+
+  it('should not decrease zoom level when zoom level is home and pinching in', () => {
+    // comp.ngOnInit();
+    // viewerService.zoomHome();
+    //
+    // pinchIn(viewerService);
+    //
+    // expect(viewerService.getZoom()).toEqual(viewerService.getHomeZoom());
+    pending('Set to pending until we find a way to perform pinch event');
+  });
+
+  it('#pageIsAtMinZoom should return true if page is at minimum zoom level', () => {
+    pending('');
+  });
+
+  it('should move image inside the view when user is panning', () => {
+    // comp.ngOnInit();
+    // viewerService.zoomTo(2);
+    // const viewer = viewerService.getViewer();
+    // const previousCenter = viewer.viewport.getCenter(false);
+    //
+    // viewer.raiseEvent('pan', {x: 150, y: 150});
+    //
+    // expect(viewerService.getCenter().x).toBeGreaterThan(previousCenter.x);
+    pending('Set to pending until we find a way to perform pan event');
+  });
+
+  it('should change page when swipeing to left', () => {
+    // modeService.mode = ViewerMode.DASHBOARD;
+    // tick();
+    // const viewer = viewerService.getViewer();
+    // viewer.raiseEvent('canvas-press', {position: {
+    //   x: 1450, y: 150}
+    // });
+    // tick(1);
+    // viewer.raiseEvent('canvas-drag-end', {position: {
+    //   x: 150, y: 150}
+    // });
+    // let pageNumber = 0;
+    // viewerService.onPageChange.subscribe(p => {
+    //   pageNumber = p;
+    // });
+    // tick(100);
+    // expect(pageNumber).toBe(10);
+    pending('Set to pending until we find a way to perform swipe event');
+  });
+
   it('should emit when page mode changes', () => {
     let selectedMode: ViewerMode;
     comp.onPageModeChange.subscribe((mode: ViewerMode) => selectedMode = mode);
@@ -115,11 +291,8 @@ describe('ViewerComponent', function () {
         }, 100);
 
         setTimeout(() => {
-          testHostFixture.detectChanges();
           expect(currentPageNumber).toEqual(1);
-          setTimeout(() => {
-            done();
-          }, 1000);
+          done();
         }, osdAnimationTime);
       }
     });
@@ -136,11 +309,8 @@ describe('ViewerComponent', function () {
     viewerService.onOsdReadyChange.subscribe((state: boolean) => {
       if (state) {
         setTimeout(() => {
-          testHostFixture.detectChanges();
           expect(currentPageNumber).toEqual(2);
-          setTimeout(() => {
-            done();
-          }, 1000);
+          done();
         }, osdAnimationTime);
       }
     });

--- a/src/lib/src/viewer/viewer.component.spec.ts
+++ b/src/lib/src/viewer/viewer.component.spec.ts
@@ -132,7 +132,7 @@ describe('ViewerComponent', function () {
           expect(modeService.mode).toBe(config.initViewerMode);
           setTimeout(() => {
             done();
-          }, 100);
+          }, 1000);
         }, osdAnimationTime);
       }
     });
@@ -297,7 +297,7 @@ describe('ViewerComponent', function () {
           expect(currentPageNumber).toEqual(1);
           setTimeout(() => {
             done();
-          }, 100);
+          }, 1000);
         }, osdAnimationTime);
       }
     });
@@ -318,7 +318,7 @@ describe('ViewerComponent', function () {
           expect(currentPageNumber).toEqual(2);
           setTimeout(() => {
             done();
-          }, 100);
+          }, 1000);
         }, osdAnimationTime);
       }
     });

--- a/src/lib/src/viewer/viewer.component.spec.ts
+++ b/src/lib/src/viewer/viewer.component.spec.ts
@@ -32,7 +32,7 @@ import '../rxjs-extension';
 
 describe('ViewerComponent', function () {
   const config: MimeViewerConfig = new MimeViewerConfig();
-  const osdAnimationTime = 4000;
+  const osdAnimationTime = 2000;
   let comp: ViewerComponent;
   let fixture: ComponentFixture<ViewerComponent>;
   let testHostComponent: TestHostComponent;
@@ -95,184 +95,6 @@ describe('ViewerComponent', function () {
 
   afterEach(function () {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
-  });
-
-  it('should create component', () => expect(comp).toBeDefined());
-
-  it('should cleanUp when manifestUri changes', () => {
-    testHostComponent.manifestUri = 'dummyURI2';
-
-    spyOn(testHostComponent.viewerComponent, 'cleanUp').and.callThrough();
-    testHostFixture.detectChanges();
-
-    expect(testHostComponent.viewerComponent.cleanUp).toHaveBeenCalled();
-  });
-
-  it('should create viewer', () => {
-    expect(viewerService.getViewer()).toBeDefined();
-  });
-
-  it('should initially open in configs intial-mode', () => {
-    expect(modeService.mode).toBe(config.initViewerMode);
-  });
-
-  it('should change mode to initial-mode when changing manifest', (done) => {
-    viewerService.onOsdReadyChange.subscribe((state: boolean) => {
-      if (state) {
-        setTimeout(() => {
-          if (config.initViewerMode === ViewerMode.PAGE) {
-            modeService.mode = ViewerMode.DASHBOARD;
-            expect(modeService.mode).toBe(ViewerMode.DASHBOARD);
-          } else {
-            modeService.mode = ViewerMode.PAGE;
-            expect(modeService.mode).toBe(ViewerMode.PAGE);
-          }
-          testHostComponent.manifestUri = 'dummyURI3';
-          testHostFixture.detectChanges();
-          expect(modeService.mode).toBe(config.initViewerMode);
-          setTimeout(() => {
-            done();
-          }, 1000);
-        }, osdAnimationTime);
-      }
-    });
-  });
-
-  it('should close all dialogs when manifestUri changes', () => {
-    testHostComponent.manifestUri = 'dummyURI2';
-
-    spyOn(testHostComponent.viewerComponent, 'cleanUp').and.callThrough();
-    testHostFixture.detectChanges();
-
-    expect(testHostComponent.viewerComponent.cleanUp).toHaveBeenCalled();
-  });
-
-  it('svgOverlay-plugin should be defined', () => {
-    expect(viewerService.getViewer().svgOverlay()).toBeDefined();
-  });
-
-  it('should create overlays', () => {
-    expect(viewerService.getOverlays()).toBeDefined();
-  });
-
-  it('should create overlays-array with same size as tilesources-array', () => {
-    expect(viewerService.getTilesources().length).toEqual(viewerService.getOverlays().length);
-  });
-
-  it('should return an OpenSeadragon.Rect with properties equal to overlay', () => {
-    let overlay = viewerService.getOverlays()[0];
-    let rect = viewerService.createRectangle(overlay);
-
-    expect(rect.x).toEqual(overlay.x.baseVal.value);
-    expect(rect.y).toEqual(overlay.y.baseVal.value);
-    expect(rect.width).toEqual(overlay.width.baseVal.value);
-    expect(rect.height).toEqual(overlay.height.baseVal.value);
-  });
-
-  it('should fit bounds to viewport for a page', (done: any) => {
-    const overlay = viewerService.getOverlays()[0];
-    const viewer = viewerService.getViewer();
-    const overlayBounds = viewerService.createRectangle(overlay);
-
-    viewerService.fitBounds(overlay);
-
-    setTimeout(() => {
-      const viewportX = Math.round(viewer.viewport.getBounds().x);
-      const viewportY = Math.round(viewer.viewport.getBounds().y);
-      const overlayX = Math.round(overlayBounds.y);
-      const overlayY = Math.round(overlayBounds.y);
-
-      expect((overlayY === viewportY) || (overlayX === viewportX)).toEqual(true);
-      done();
-    }, 0);
-
-  });
-
-  it('should return overlay-index if target is an overlay', () => {
-    let overlay, index;
-    overlay = viewerService.getOverlays()[0];
-    index = viewerService.getOverlayIndexFromClickEvent(overlay);
-    expect(index).toBe(0);
-
-    overlay = viewerService.getOverlays()[1];
-    index = viewerService.getOverlayIndexFromClickEvent(overlay);
-    expect(index).toBe(1);
-
-    overlay = viewerService.getOverlays()[12];
-    index = viewerService.getOverlayIndexFromClickEvent(overlay);
-    expect(index).toBe(12);
-
-    // Should return -1 for nonsense overlay
-    overlay = viewerService.getOverlays()[12000];
-    index = viewerService.getOverlayIndexFromClickEvent(overlay);
-    expect(index).toBe(-1);
-
-  });
-
-  it('should increase zoom level when pinching out', () => {
-    // comp.ngOnInit();
-    //
-    // pinchOut(viewerService);
-    //
-    // expect(viewerService.getZoom()).toBeGreaterThan(viewerService.getHomeZoom());
-    pending('Set to pending until we find a way to perform pinch event');
-  });
-
-  it('should decrease zoom level when is zoomed in and pinching in', () => {
-    // comp.ngOnInit();
-    // const previousZoom = 1;
-    // viewerService.zoomTo(previousZoom);
-    //
-    // pinchIn(viewerService);
-    //
-    // expect(viewerService.getZoom()).toBeLessThan(previousZoom);
-    pending('Set to pending until we find a way to perform pinch event');
-  });
-
-  it('should not decrease zoom level when zoom level is home and pinching in', () => {
-    // comp.ngOnInit();
-    // viewerService.zoomHome();
-    //
-    // pinchIn(viewerService);
-    //
-    // expect(viewerService.getZoom()).toEqual(viewerService.getHomeZoom());
-    pending('Set to pending until we find a way to perform pinch event');
-  });
-
-  it('#pageIsAtMinZoom should return true if page is at minimum zoom level', () => {
-    pending('');
-  });
-
-  it('should move image inside the view when user is panning', () => {
-    // comp.ngOnInit();
-    // viewerService.zoomTo(2);
-    // const viewer = viewerService.getViewer();
-    // const previousCenter = viewer.viewport.getCenter(false);
-    //
-    // viewer.raiseEvent('pan', {x: 150, y: 150});
-    //
-    // expect(viewerService.getCenter().x).toBeGreaterThan(previousCenter.x);
-    pending('Set to pending until we find a way to perform pan event');
-  });
-
-  it('should change page when swipeing to left', () => {
-    // modeService.mode = ViewerMode.DASHBOARD;
-    // tick();
-    // const viewer = viewerService.getViewer();
-    // viewer.raiseEvent('canvas-press', {position: {
-    //   x: 1450, y: 150}
-    // });
-    // tick(1);
-    // viewer.raiseEvent('canvas-drag-end', {position: {
-    //   x: 150, y: 150}
-    // });
-    // let pageNumber = 0;
-    // viewerService.onPageChange.subscribe(p => {
-    //   pageNumber = p;
-    // });
-    // tick(100);
-    // expect(pageNumber).toBe(10);
-    pending('Set to pending until we find a way to perform swipe event');
   });
 
   it('should emit when page mode changes', () => {
@@ -354,7 +176,7 @@ export class TestHostComponent {
   public manifestUri: string;
   public canvasIndex = 0;
   public config = new MimeViewerConfig({
-    attributionDialogHideTimeout: 1
+    attributionDialogHideTimeout: -1
   });
 }
 

--- a/src/lib/src/viewer/viewer.component.spec.ts
+++ b/src/lib/src/viewer/viewer.component.spec.ts
@@ -99,13 +99,12 @@ describe('ViewerComponent', function () {
 
   it('should create component', () => expect(comp).toBeDefined());
 
-  it('should cleanUp when manifestUri changes', () => {
+  it('should cleanup when manifestUri changes', () => {
+    spyOn(testHostComponent.viewerComponent, 'cleanup').and.callThrough();
     testHostComponent.manifestUri = 'dummyURI2';
-
-    spyOn(testHostComponent.viewerComponent, 'cleanUp').and.callThrough();
     testHostFixture.detectChanges();
 
-    expect(testHostComponent.viewerComponent.cleanUp).toHaveBeenCalled();
+    expect(testHostComponent.viewerComponent.cleanup).toHaveBeenCalled();
   });
 
   it('should create viewer', () => {
@@ -139,10 +138,10 @@ describe('ViewerComponent', function () {
   it('should close all dialogs when manifestUri changes', () => {
     testHostComponent.manifestUri = 'dummyURI2';
 
-    spyOn(testHostComponent.viewerComponent, 'cleanUp').and.callThrough();
+    spyOn(testHostComponent.viewerComponent, 'cleanup').and.callThrough();
     testHostFixture.detectChanges();
 
-    expect(testHostComponent.viewerComponent.cleanUp).toHaveBeenCalled();
+    expect(testHostComponent.viewerComponent.cleanup).toHaveBeenCalled();
   });
 
   it('svgOverlay-plugin should be defined', () => {

--- a/src/lib/src/viewer/viewer.component.spec.ts
+++ b/src/lib/src/viewer/viewer.component.spec.ts
@@ -32,7 +32,7 @@ import '../rxjs-extension';
 
 describe('ViewerComponent', function () {
   const config: MimeViewerConfig = new MimeViewerConfig();
-  const osdAnimationTime = 1500;
+  const osdAnimationTime = 4000;
   let comp: ViewerComponent;
   let fixture: ComponentFixture<ViewerComponent>;
   let testHostComponent: TestHostComponent;
@@ -130,7 +130,9 @@ describe('ViewerComponent', function () {
           testHostComponent.manifestUri = 'dummyURI3';
           testHostFixture.detectChanges();
           expect(modeService.mode).toBe(config.initViewerMode);
-          done();
+          setTimeout(() => {
+            done();
+          }, 100);
         }, osdAnimationTime);
       }
     });
@@ -284,16 +286,21 @@ describe('ViewerComponent', function () {
   it('should emit when page number changes', (done) => {
     let currentPageNumber: number;
     comp.onPageChange.subscribe((pageNumber: number) => currentPageNumber = pageNumber);
-    setTimeout(() => {
-      fixture.detectChanges();
-      viewerService.goToPage(1, false);
-      fixture.detectChanges();
-    }, 2000);
-    setTimeout(() => {
-      fixture.detectChanges();
-      expect(currentPageNumber).toEqual(1);
-      done();
-    }, 4000);
+    viewerService.onOsdReadyChange.subscribe((state: boolean) => {
+      if (state) {
+        setTimeout(() => {
+          viewerService.goToPage(1, false);
+        }, 100);
+
+        setTimeout(() => {
+          testHostFixture.detectChanges();
+          expect(currentPageNumber).toEqual(1);
+          setTimeout(() => {
+            done();
+          }, 100);
+        }, osdAnimationTime);
+      }
+    });
   });
 
   it('should open viewer on canvas index if present', (done) => {
@@ -307,8 +314,11 @@ describe('ViewerComponent', function () {
     viewerService.onOsdReadyChange.subscribe((state: boolean) => {
       if (state) {
         setTimeout(() => {
+          testHostFixture.detectChanges();
           expect(currentPageNumber).toEqual(2);
-          done();
+          setTimeout(() => {
+            done();
+          }, 100);
         }, osdAnimationTime);
       }
     });
@@ -336,13 +346,16 @@ describe('ViewerComponent', function () {
 
 @Component({
   selector: `test-component`,
-  template: `<mime-viewer [manifestUri]="manifestUri" [canvasIndex]="canvasIndex"></mime-viewer>`
+  template: `<mime-viewer [manifestUri]="manifestUri" [canvasIndex]="canvasIndex" [config]="config"></mime-viewer>`
 })
 export class TestHostComponent {
   @ViewChild(ViewerComponent)
   public viewerComponent: any;
   public manifestUri: string;
   public canvasIndex = 0;
+  public config = new MimeViewerConfig({
+    attributionDialogHideTimeout: 1
+  });
 }
 
 class IiifManifestServiceStub {

--- a/src/lib/src/viewer/viewer.component.ts
+++ b/src/lib/src/viewer/viewer.component.ts
@@ -78,17 +78,17 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnInit(): void {
-    this.attributionDialogService.initialize();
-    this.contentsDialogService.initialize();
-    this.contentSearchDialogService.initialize();
     this.modeService.initialMode = this.config.initViewerMode;
     this.subscriptions.push(
       this.iiifManifestService.currentManifest
         .subscribe((manifest: Manifest) => {
           if (manifest) {
+            this.destroy();
+            this.attributionDialogService.initialize();
+            this.contentsDialogService.initialize();
+            this.contentSearchDialogService.initialize();
             this.resetErrorMessage();
             this.currentManifest = manifest;
-            this.cleanUp();
             this.changeDetectorRef.detectChanges();
             this.viewerService.setUpViewer(manifest);
             if (this.config.attributionDialogEnabled && manifest.attribution) {
@@ -175,7 +175,7 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     if (manifestUriIsChanged) {
-      this.cleanUp();
+      this.destroy();
       this.loadManifest();
     } else {
       if (qIsChanged) {
@@ -191,19 +191,19 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
     this.subscriptions.forEach((subscription: Subscription) => {
       subscription.unsubscribe();
     });
-    this.attributionDialogService.destroy();
-    this.contentsDialogService.destroy();
-    this.contentSearchDialogService.destroy();
-    this.iiifContentSearchService.destroy();
+    this.destroy();
     this.iiifManifestService.destroy();
+    this.iiifContentSearchService.destroy();
   }
 
   // ChangeDetection fix
   onModeChange() {
+    /*
     if (this.modeService.mode === ViewerMode.DASHBOARD) {
-      this.contentsDialogService.cleanUp();
-      this.contentSearchDialogService.cleanUp();
+      this.contentsDialogService.destroy();
+      this.contentSearchDialogService.destroy();
     }
+    */
   }
 
   toggleToolbarsState(mode: ViewerMode): void {
@@ -234,12 +234,11 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
     this.iiifManifestService.load(this.manifestUri);
   }
 
-  private cleanUp() {
+  private destroy() {
+    this.attributionDialogService.destroy();
+    this.contentsDialogService.destroy();
+    this.contentSearchDialogService.destroy();
     this.viewerService.destroy();
-    this.attributionDialogService.cleanUp();
-    this.contentsDialogService.cleanUp();
-    this.contentSearchDialogService.cleanUp();
-    this.iiifContentSearchService.destroy();
   }
 
   private resetCurrentManifest(): void {

--- a/src/lib/src/viewer/viewer.component.ts
+++ b/src/lib/src/viewer/viewer.component.ts
@@ -78,6 +78,9 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnInit(): void {
+    this.attributionDialogService.initialize();
+    this.contentsDialogService.initialize();
+    this.contentSearchDialogService.initialize();
     this.modeService.initialMode = this.config.initViewerMode;
     this.subscriptions.push(
       this.iiifManifestService.currentManifest
@@ -198,8 +201,8 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
   // ChangeDetection fix
   onModeChange() {
     if (this.modeService.mode === ViewerMode.DASHBOARD) {
-      this.contentsDialogService.destroy();
-      this.contentSearchDialogService.destroy();
+      this.contentsDialogService.cleanUp();
+      this.contentSearchDialogService.cleanUp();
     }
   }
 
@@ -233,9 +236,9 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
 
   private cleanUp() {
     this.viewerService.destroy();
-    this.attributionDialogService.destroy();
-    this.contentsDialogService.destroy();
-    this.contentSearchDialogService.destroy();
+    this.attributionDialogService.cleanUp();
+    this.contentsDialogService.cleanUp();
+    this.contentSearchDialogService.cleanUp();
     this.iiifContentSearchService.destroy();
   }
 

--- a/src/lib/src/viewer/viewer.component.ts
+++ b/src/lib/src/viewer/viewer.component.ts
@@ -83,11 +83,8 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
       this.iiifManifestService.currentManifest
         .subscribe((manifest: Manifest) => {
           if (manifest) {
-            this.destroy();
-            this.attributionDialogService.initialize();
-            this.contentsDialogService.initialize();
-            this.contentSearchDialogService.initialize();
-            this.resetErrorMessage();
+            this.cleanup();
+            this.initialize();
             this.currentManifest = manifest;
             this.changeDetectorRef.detectChanges();
             this.viewerService.setUpViewer(manifest);
@@ -175,7 +172,7 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     if (manifestUriIsChanged) {
-      this.destroy();
+      this.cleanup();
       this.loadManifest();
     } else {
       if (qIsChanged) {
@@ -191,7 +188,7 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
     this.subscriptions.forEach((subscription: Subscription) => {
       subscription.unsubscribe();
     });
-    this.destroy();
+    this.cleanup();
     this.iiifManifestService.destroy();
     this.iiifContentSearchService.destroy();
   }
@@ -234,11 +231,18 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
     this.iiifManifestService.load(this.manifestUri);
   }
 
-  private destroy() {
+  private initialize() {
+    this.attributionDialogService.initialize();
+    this.contentsDialogService.initialize();
+    this.contentSearchDialogService.initialize();
+  }
+
+  private cleanup() {
     this.attributionDialogService.destroy();
     this.contentsDialogService.destroy();
     this.contentSearchDialogService.destroy();
     this.viewerService.destroy();
+    this.resetErrorMessage();
   }
 
   private resetCurrentManifest(): void {


### PR DESCRIPTION
Fixes "Uncaught Error: ViewDestroyedError: Attempt to use a destroyed view: detectChanges
  at node_modules/zone.js/dist/zone.js:195"

Probably the attributes dialog that runs animations after the view is destroyed