### PR TITLE
fix: NGXMIM-36: spacing between footer and end of page on small screens

### DIFF
--- a/src/lib/src/viewer/viewer.component.scss
+++ b/src/lib/src/viewer/viewer.component.scss
@@ -79,3 +79,9 @@
   width: 100%;
   height: 100%;
 }
+
+@media(max-width:600px) {
+  .navbar {
+    height: 56px;
+  }
+}


### PR DESCRIPTION
Set .navbar height to 56px on screens under 600px since Angular Materials md-toolbar does the same