### PR TITLE
fix: page no longer zooms out before going to next page in zoomed in mode

### DIFF
--- a/src/lib/src/core/viewer-service/viewer.service.ts
+++ b/src/lib/src/core/viewer-service/viewer.service.ts
@@ -166,6 +166,7 @@ export class ViewerService {
       this.goToHomeZoom();
       setTimeout(() => {
         this.panTo(newPageCenter.centerX, newPageCenter.centerY, immediately);
+        this.modeService.mode = ViewerMode.PAGE;
       }, ViewerOptions.transitions.OSDAnimationTime);
     } else {
       this.panTo(newPageCenter.centerX, newPageCenter.centerY, immediately);
@@ -707,10 +708,6 @@ export class ViewerService {
 
   private goToHomeZoom(): void {
     this.zoomTo(this.getHomeZoomLevel(this.modeService.mode));
-
-    if (this.modeService.mode === ViewerMode.PAGE_ZOOMED) {
-      this.modeService.mode = ViewerMode.PAGE;
-    }
   }
 
   private getHomeZoomLevel(mode: ViewerMode): number {


### PR DESCRIPTION
Remove setting to page-mode on goToHomeZoom() fixes this issue