### PR TITLE
feat: navigate between pages with arrow keys

### DIFF
--- a/src/lib/src/core/viewer-service/viewer.service.ts
+++ b/src/lib/src/core/viewer-service/viewer.service.ts
@@ -300,6 +300,14 @@ export class ViewerService {
     this.viewer.addHandler('animation', (e: any) => {
       this.currentCenter.next(this.viewer.viewport.getCenter(true));
     });
+
+    this.disableOSDKeyhandlers();
+  }
+
+  private disableOSDKeyhandlers(): void {
+    this.viewer.innerTracker.keyHandler = null;
+    this.viewer.innerTracker.keyDownHandler = null;
+    this.viewer.innerTracker.keyPressHandler = null;
   }
 
 

--- a/src/lib/src/viewer/viewer.component.ts
+++ b/src/lib/src/viewer/viewer.component.ts
@@ -3,12 +3,13 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  EventEmitter,
+  HostListener,
   Input,
-  Output,
   OnChanges,
   OnDestroy,
   OnInit,
-  EventEmitter,
+  Output,
   SimpleChange,
   SimpleChanges,
   ViewChild,
@@ -255,6 +256,18 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
 
   private resetErrorMessage(): void {
     this.errorMessage = null;
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  private handleKeyboardEvent(event: KeyboardEvent): void {
+    switch (event.key) {
+      case 'ArrowRight':
+        this.viewerService.goToNextPage();
+        break;
+      case 'ArrowLeft':
+        this.viewerService.goToPreviousPage();
+        break;
+    }
   }
 
   setClasses() {


### PR DESCRIPTION
- Disables all of OSD default keyboardhandlers (listed here: https://openseadragon.github.io/examples/ui-keyboard-navigation/)
- Added goto next/previous page with right/left arrowkeys