### PR TITLE
fix: OSD toolbar takes full width in IE11

### DIFF
--- a/src/lib/src/viewer/osd-toolbar/osd-toolbar.component.scss
+++ b/src/lib/src/viewer/osd-toolbar/osd-toolbar.component.scss
@@ -5,7 +5,7 @@
 .osd-toolbar {
   position: absolute;
   background: transparent;
-  width: initial;
+  width: auto;
   z-index: 2;
 }
 


### PR DESCRIPTION
Fixes #197