### PR TITLE
fix: fixing lint error

### DIFF
--- a/src/lib/src/core/iiif-content-search-service/iiif-content-search.service.ts
+++ b/src/lib/src/core/iiif-content-search-service/iiif-content-search.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { Observable, Subject, BehaviorSubject } from 'rxjs';
+import { Observable, Subject, BehaviorSubject, throwError } from 'rxjs';
 import { distinctUntilChanged, finalize } from 'rxjs/operators';
 
 import { IiifSearchResult } from './../models/iiif-search-result';
@@ -74,6 +74,6 @@ export class IiifContentSearchService {
     } else {
       errMsg = err.error;
     }
-    return Observable.throw(errMsg);
+    return throwError(errMsg);
   }
 }


### PR DESCRIPTION
Fixes 

WARNING: /home/travis/build/NationalLibraryOfNorway/ngx-mime/src/lib/src/core/iiif-content-search-service/iiif-content-search.service.ts[77, 23]: throw is deprecated: In favor of throwError creation function: import { throwError } from 'rxjs';