### PR TITLE
test(e2e): forcing firefox v62

### DIFF
--- a/apps/integration-e2e/remote-browsers.js
+++ b/apps/integration-e2e/remote-browsers.js
@@ -5,7 +5,7 @@ exports.customDesktopLaunchers = [
   },
   {
     browserName: 'firefox',
-    version: 'latest'
+    version: '62.0'
   },
   {
     browserName: 'MicrosoftEdge',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Firefox v63 opens a update dialog after 4 minutes that causes e2e tests to fail

## What is the new behavior?
Forcing Firefox v62

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
