### PR TITLE
fix: align navigation button label

### DIFF
--- a/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.html
+++ b/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.html
@@ -17,8 +17,11 @@
       class="canvasGroups"
       (click)="openCanvasGroupDialog()"
     >
-      <span id="currentCanvasGroupLabel">{{ canvasGroupLabel }}</span
-      >/ <span id="numOfCanvasGroups">{{ numberOfCanvases }}</span>
+      <div fxLayout="row" fxLayoutGap="1px">
+        <span id="currentCanvasGroupLabel">{{ canvasGroupLabel }}</span
+        ><span>/</span
+        ><span id="numOfCanvasGroups">{{ numberOfCanvases }}</span>
+      </div>
     </button>
     <div class="navigation-buttons">
       <button


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Navigation button label is not horizontally aligned, and gap between pagenumber and number of pages is not equal
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
- Navigation button label is horizontally aligned. 
- Gap between pagenumber and number of pages equal

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
