### PR TITLE
feat: better scaling in dashboard view

### DIFF
--- a/apps/integration/src/app/viewer/viewer.component.spec.ts
+++ b/apps/integration/src/app/viewer/viewer.component.spec.ts
@@ -1,9 +1,9 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { ViewerComponent } from './viewer.component';
-import { MimeModule } from '@nationallibraryofnorway/ngx-mime';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MimeModule } from '@nationallibraryofnorway/ngx-mime';
+import { ViewerComponent } from './viewer.component';
 
 describe('ViewerComponent', () => {
   let component: ViewerComponent;

--- a/apps/integration/src/app/viewer/viewer.component.spec.ts
+++ b/apps/integration/src/app/viewer/viewer.component.spec.ts
@@ -3,6 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ViewerComponent } from './viewer.component';
 import { MimeModule } from '@nationallibraryofnorway/ngx-mime';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('ViewerComponent', () => {
   let component: ViewerComponent;
@@ -10,7 +11,12 @@ describe('ViewerComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MimeModule, RouterTestingModule, HttpClientTestingModule],
+      imports: [
+        MimeModule,
+        RouterTestingModule,
+        HttpClientTestingModule,
+        NoopAnimationsModule
+      ],
       declarations: [ViewerComponent]
     }).compileComponents();
   }));

--- a/libs/ngx-mime/src/lib/core/viewer-service/zoom-strategy.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/zoom-strategy.ts
@@ -70,7 +70,6 @@ export class ZoomStrategy {
       return;
     }
 
-    const homeZoomFactor = this.getHomeZoomFactor();
     let canvasGroupHeight: number;
     let canvasGroupWidth: number;
     let viewportBounds: any;
@@ -86,12 +85,10 @@ export class ZoomStrategy {
       viewportBounds = this.viewer.viewport.getBounds();
     }
 
-    return (
-      this.getFittedZoomLevel(
-        viewportBounds,
-        canvasGroupHeight,
-        canvasGroupWidth
-      ) * homeZoomFactor
+    return this.getFittedZoomLevel(
+      viewportBounds,
+      canvasGroupHeight,
+      canvasGroupWidth
     );
   }
 
@@ -140,6 +137,7 @@ export class ZoomStrategy {
       return;
     }
 
+    const homeZoomFactor = this.getHomeZoomFactor();
     const maxViewportDimensions = new Dimensions(
       d3
         .select(this.viewer.container.parentNode.parentNode)
@@ -150,7 +148,7 @@ export class ZoomStrategy {
       maxViewportDimensions.height -
       ViewerOptions.padding.header -
       ViewerOptions.padding.footer;
-    const viewportWidth = maxViewportDimensions.width;
+    const viewportWidth = maxViewportDimensions.width * homeZoomFactor;
 
     const viewportSizeInViewportCoordinates = this.viewer.viewport.deltaPointsFromPixels(
       new OpenSeadragon.Point(viewportWidth, viewportHeight)


### PR DESCRIPTION
Should show show partial previous and next page in dashboard view

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Pages in dashboard view is unnecessary small when viewport is very wide

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Pages can have fulll viewport heigh

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
