### PR TITLE
fix(a11y): added 'display: none' to OSD toolbar in hidden state

### DIFF
--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
@@ -1,5 +1,6 @@
 import {
   animate,
+  group,
   state,
   style,
   transition,
@@ -40,18 +41,23 @@ import { ViewerService } from './../../core/viewer-service/viewer.service';
       state(
         'hide',
         style({
-          transform: 'translate(-120px, 0)'
+          transform: 'translate(-120px, 0)',
+          display: 'none'
         })
       ),
       state(
         'show',
         style({
-          transform: 'translate(0px, 0px)'
+          transform: 'translate(0px, 0px)',
+          display: 'block'
         })
       ),
       transition(
         'hide => show',
-        animate(`${ViewerOptions.transitions.toolbarsEaseInTime}ms ease-out`)
+        [group([
+          style({display: 'block'}),
+          animate(`${ViewerOptions.transitions.toolbarsEaseInTime}ms ease-out`)
+        ])]
       ),
       transition(
         'show => hide',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

OSD toolbar is focusable in it's hidden state and readable by screenreaders.

Issue Number: https://github.com/NationalLibraryOfNorway/ngx-mime/issues/263

## What is the new behavior?
OSD toolbar is set to display: none when it has state 'hidden'. No longer focusable when offscreen.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
