### PR TITLE
fix: correct aria-label for dialogclose buttons

### DIFF
--- a/libs/ngx-mime/src/lib/content-search-dialog/content-search-dialog.component.html
+++ b/libs/ngx-mime/src/lib/content-search-dialog/content-search-dialog.component.html
@@ -6,7 +6,7 @@
           <button
             id="close-content-search-dialog-button"
             mat-icon-button
-            [attr.aria-label]="intl.closeLabel"
+            [aria-label]="intl.closeLabel"
             [matTooltip]="intl.closeLabel"
             [matDialogClose]="true"
             tabindex="-1"
@@ -24,7 +24,7 @@
           <button
             id="close-content-search-dialog-button"
             mat-icon-button
-            [attr.aria-label]="intl.closeLabel"
+            [aria-label]="intl.closeLabel"
             [matTooltip]="intl.closeLabel"
             [matDialogClose]="true"
             tabindex="-1"

--- a/libs/ngx-mime/src/lib/contents-dialog/contents-dialog.component.html
+++ b/libs/ngx-mime/src/lib/contents-dialog/contents-dialog.component.html
@@ -5,7 +5,7 @@
         <div fxLayout="row" fxLayoutAlign="start center">
           <button
             mat-icon-button
-            [attr.aria-label]="intl.closeLabel"
+            [aria-label]="intl.closeLabel"
             [matTooltip]="intl.closeLabel"
             [matDialogClose]="true"
             tabindex="-1"
@@ -22,7 +22,7 @@
           <div class="heading heading-desktop">{{ intl.contentsLabel }}</div>
           <button
             mat-icon-button
-            [attr.aria-label]="intl.closeLabel"
+            [aria-label]="intl.closeLabel"
             [matTooltip]="intl.closeLabel"
             [matDialogClose]="true"
             tabindex="-1"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/NationalLibraryOfNorway/ngx-mime/issues/261

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Changed [attr.aria-label] -> [aria-label] for buttons with matDialogClose
