### PR TITLE
test(e2e): fix stale reference error in e2e test

### DIFF
--- a/apps/integration-e2e/pages/viewer.po.ts
+++ b/apps/integration-e2e/pages/viewer.po.ts
@@ -250,7 +250,7 @@ export class ViewerPage {
 
   async getTwoPageButton() {
     const el = element(by.css('#toggleTwoPageViewButton'));
-    if ((await el.isPresent()) && el.isDisplayed()) {
+    if ((await el.isPresent()) && (await el.isDisplayed())) {
       return el;
     } else {
       return false;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "pree2e:firefox": "yarn pree2e",
     "mountebank": "mb --port 2020 --configfile ./apps/integration-e2e/templates/imposters.ejs --allowInjection --nologfile",
     "e2e": "yarn e2e:chrome",
-    "e2e:ci": "concurrently \"yarn mountebank\" \"yarn start:integration\" \"yarn protractor:desktop && yarn protractor:mobile\" --kill-other s --success first",
+    "e2e:ci": "concurrently \"yarn mountebank\" \"yarn start:integration\" \"yarn protractor:desktop && yarn protractor:mobile\" --kill-others --success first",
     "e2e:chrome": "concurrently \"yarn mountebank\" \"yarn start:integration\" \"yarn protractor:chrome:headless\" --kill-others --success first",
     "e2e:firefox": "concurrently \"yarn mountebank\" \"yarn start:integration\" \"yarn protractor:firefox:headless\" --kill-others --success first",
     "wait": "sh  ./apps/integration-e2e/scripts/wait-on.sh",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When running e2e tests this error occurs:
 UnhandledPromiseRejectionWarning: StaleElementReferenceError: stale element reference: element is not attached to the page document
 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Handles Promise

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
