### PR TITLE
Fix/canvas group navigator buttons

### DIFF
--- a/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.html
+++ b/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.html
@@ -33,7 +33,7 @@
           [attr.aria-label]="intl.previousPageLabel"
           [matTooltip]="intl.previousPageLabel"
           matTooltipPosition="above"
-          [disabled]="isFirstCanvasGroup"
+          [disabled]="isOnFirstCanvasGroup()"
           (click)="goToPreviousCanvasGroup()"
         >
           <mat-icon>navigate_before</mat-icon>
@@ -44,7 +44,7 @@
           [attr.aria-label]="intl.nextPageLabel"
           [matTooltip]="intl.nextPageLabel"
           matTooltipPosition="above"
-          [disabled]="isLastCanvasGroup"
+          [disabled]="isOnLastCanvasGroup()"
           (click)="goToNextCanvasGroup()"
         >
           <mat-icon>navigate_next</mat-icon>
@@ -57,7 +57,7 @@
           [attr.aria-label]="intl.nextPageLabel"
           [matTooltip]="intl.nextPageLabel"
           matTooltipPosition="above"
-          [disabled]="isLastCanvasGroup"
+          [disabled]="isOnLastCanvasGroup()"
           (click)="goToNextCanvasGroup()"
         >
           <mat-icon>navigate_before</mat-icon>
@@ -68,7 +68,7 @@
           [attr.aria-label]="intl.previousPageLabel"
           [matTooltip]="intl.previousPageLabel"
           matTooltipPosition="above"
-          [disabled]="isFirstCanvasGroup"
+          [disabled]="isOnFirstCanvasGroup()"
           (click)="goToPreviousCanvasGroup()"
         >
           <mat-icon>navigate_next</mat-icon>

--- a/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.html
+++ b/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.html
@@ -33,7 +33,7 @@
           [attr.aria-label]="intl.previousPageLabel"
           [matTooltip]="intl.previousPageLabel"
           matTooltipPosition="above"
-          [disabled]="isOnFirstCanvasGroup()"
+          [disabled]="isFirstCanvasGroup"
           (click)="goToPreviousCanvasGroup()"
         >
           <mat-icon>navigate_before</mat-icon>
@@ -44,7 +44,7 @@
           [attr.aria-label]="intl.nextPageLabel"
           [matTooltip]="intl.nextPageLabel"
           matTooltipPosition="above"
-          [disabled]="isOnLastCanvasGroup()"
+          [disabled]="isLastCanvasGroup"
           (click)="goToNextCanvasGroup()"
         >
           <mat-icon>navigate_next</mat-icon>
@@ -57,7 +57,7 @@
           [attr.aria-label]="intl.nextPageLabel"
           [matTooltip]="intl.nextPageLabel"
           matTooltipPosition="above"
-          [disabled]="isOnLastCanvasGroup()"
+          [disabled]="isLastCanvasGroup"
           (click)="goToNextCanvasGroup()"
         >
           <mat-icon>navigate_before</mat-icon>
@@ -68,7 +68,7 @@
           [attr.aria-label]="intl.previousPageLabel"
           [matTooltip]="intl.previousPageLabel"
           matTooltipPosition="above"
-          [disabled]="isOnFirstCanvasGroup()"
+          [disabled]="isFirstCanvasGroup"
           (click)="goToPreviousCanvasGroup()"
         >
           <mat-icon>navigate_next</mat-icon>

--- a/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.spec.ts
@@ -154,7 +154,7 @@ describe('CanvasGroupNavigatorComponent', () => {
     )
   ));
 
-  it('should disable next/previous canvas group', async(
+  it('should disable previous and next button if there is only one canvas', async(
     inject(
       [ViewerService, CanvasService],
       (viewerService: ViewerServiceStub, canvasService: CanvasServiceStub) => {

--- a/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.spec.ts
@@ -9,6 +9,8 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { CanvasGroupDialogService } from '../../../canvas-group-dialog/canvas-group-dialog.service';
 import { IiifManifestService } from '../../../core/iiif-manifest-service/iiif-manifest-service';
+import { Rect } from '../../../core/models/rect';
+import { ViewerLayout } from '../../../core/models/viewer-layout';
 import { CanvasServiceStub } from '../../../test/canvas-service-stub';
 import { IiifManifestServiceStub } from '../../../test/iiif-manifest-service-stub';
 import { ViewerServiceStub } from '../../../test/viewer-service-stub';
@@ -94,9 +96,8 @@ describe('CanvasGroupNavigatorComponent', () => {
     }
   ));
 
-  it('should disable next button when viewer is on last canvas group', async(inject(
-    [CanvasService],
-    (canvasService: CanvasServiceStub) => {
+  it('should disable next button when viewer is on last canvas group', async(
+    inject([CanvasService], (canvasService: CanvasServiceStub) => {
       canvasService._currentNumberOfCanvasGroups.next(10);
 
       canvasService._currentCanvasGroupIndex.next(9);
@@ -108,25 +109,27 @@ describe('CanvasGroupNavigatorComponent', () => {
         );
         expect(button.nativeElement.disabled).toBeTruthy();
       });
-    }
-  )));
+    })
+  ));
 
-  it('should display next canvas group', async(inject(
-    [ViewerService, CanvasService],
-    (viewerService: ViewerServiceStub, canvasService: CanvasServiceStub) => {
-      spy = spyOn(viewerService, 'goToNextCanvasGroup');
+  it('should display next canvas group', async(
+    inject(
+      [ViewerService, CanvasService],
+      (viewerService: ViewerServiceStub, canvasService: CanvasServiceStub) => {
+        spy = spyOn(viewerService, 'goToNextCanvasGroup');
 
-      const button = fixture.debugElement.query(
-        By.css('#footerNavigateNextButton')
-      );
-      button.nativeElement.click();
+        const button = fixture.debugElement.query(
+          By.css('#footerNavigateNextButton')
+        );
+        button.nativeElement.click();
 
-      fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        expect(spy.calls.count()).toEqual(1);
-      });
-    }
-  )));
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(spy.calls.count()).toEqual(1);
+        });
+      }
+    )
+  ));
 
   it('should display previous canvas group', async(
     inject(
@@ -146,6 +149,28 @@ describe('CanvasGroupNavigatorComponent', () => {
           fixture.whenStable().then(() => {
             expect(spy.calls.count()).toEqual(1);
           });
+        });
+      }
+    )
+  ));
+
+  it('should disable next/previous canvas group', async(
+    inject(
+      [ViewerService, CanvasService],
+      (viewerService: ViewerServiceStub, canvasService: CanvasServiceStub) => {
+        canvasService.addAll([new Rect()], ViewerLayout.ONE_PAGE);
+        fixture.detectChanges();
+
+        fixture.whenStable().then(() => {
+          const previousButton = fixture.debugElement.query(
+            By.css('#footerNavigateBeforeButton')
+          );
+          const nextButton = fixture.debugElement.query(
+            By.css('#footerNavigateNextButton')
+          );
+
+          expect(nextButton.nativeElement.disabled).toBeTrue();
+          expect(previousButton.nativeElement.disabled).toBeTrue();
         });
       }
     )

--- a/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.ts
@@ -65,12 +65,6 @@ export class CanvasGroupNavigatorComponent implements OnInit, OnDestroy {
             this.currentCanvasGroupIndex
           );
         }
-        this.isFirstCanvasGroup = this.isOnFirstCanvasGroup(
-          currentCanvasGroupIndex
-        );
-        this.isLastCanvasGroup = this.isOnLastCanvasGroup(
-          currentCanvasGroupIndex
-        );
         this.changeDetectorRef.detectChanges();
       });
 
@@ -110,11 +104,11 @@ export class CanvasGroupNavigatorComponent implements OnInit, OnDestroy {
     this.pageDialogService.toggle();
   }
 
-  private isOnFirstCanvasGroup(currentCanvasGroupIndex: number): boolean {
-    return currentCanvasGroupIndex === 0;
+  isOnFirstCanvasGroup(): boolean {
+    return this.currentCanvasGroupIndex === 0;
   }
 
-  private isOnLastCanvasGroup(currentCanvasGroupIndex: number): boolean {
-    return currentCanvasGroupIndex === this.numberOfCanvasGroups - 1;
+  isOnLastCanvasGroup(): boolean {
+    return this.currentCanvasGroupIndex === this.numberOfCanvasGroups - 1;
   }
 }

--- a/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.ts
@@ -65,6 +65,12 @@ export class CanvasGroupNavigatorComponent implements OnInit, OnDestroy {
             this.currentCanvasGroupIndex
           );
         }
+        this.isFirstCanvasGroup = this.isOnFirstCanvasGroup(
+          currentCanvasGroupIndex
+        );
+        this.isLastCanvasGroup = this.isOnLastCanvasGroup(
+          currentCanvasGroupIndex
+        );
         this.changeDetectorRef.detectChanges();
       });
 
@@ -73,6 +79,12 @@ export class CanvasGroupNavigatorComponent implements OnInit, OnDestroy {
       .subscribe((numberOfCanvasGroups: number) => {
         this.numberOfCanvasGroups = numberOfCanvasGroups;
         this.numberOfCanvases = this.canvasService.numberOfCanvases;
+        this.isFirstCanvasGroup = this.isOnFirstCanvasGroup(
+          this.currentCanvasGroupIndex
+        );
+        this.isLastCanvasGroup = this.isOnLastCanvasGroup(
+          this.currentCanvasGroupIndex
+        );
         this.changeDetectorRef.detectChanges();
       });
   }
@@ -104,11 +116,11 @@ export class CanvasGroupNavigatorComponent implements OnInit, OnDestroy {
     this.pageDialogService.toggle();
   }
 
-  isOnFirstCanvasGroup(): boolean {
-    return this.currentCanvasGroupIndex === 0;
+  private isOnFirstCanvasGroup(currentCanvasGroupIndex: number): boolean {
+    return currentCanvasGroupIndex === 0;
   }
 
-  isOnLastCanvasGroup(): boolean {
-    return this.currentCanvasGroupIndex === this.numberOfCanvasGroups - 1;
+  private isOnLastCanvasGroup(currentCanvasGroupIndex: number): boolean {
+    return currentCanvasGroupIndex === this.numberOfCanvasGroups - 1;
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

State for next/previous buttons in footer is only updated when the current page number is changed. Because the page initial page number is 0 it is never recalculated when loading a single page document leading the next page to be enabled although the first page is also the last page.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The state of the next/previous buttons are no recalculated whenever any properties change.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
