### PR TITLE
fix: avoid buttons overflowing on IE

### DIFF
--- a/libs/ngx-mime/src/lib/viewer/viewer-header/viewer-header.component.html
+++ b/libs/ngx-mime/src/lib/viewer/viewer-header/viewer-header.component.html
@@ -9,7 +9,7 @@
       manifest?.label
     }}</div>
     <div
-      fxFlex
+      fxFlex="auto"
       fxLayout="row"
       fxLayoutAlign="end center"
       class="buttons-container"

--- a/libs/ngx-mime/src/lib/viewer/viewer-header/viewer-header.component.html
+++ b/libs/ngx-mime/src/lib/viewer/viewer-header/viewer-header.component.html
@@ -9,7 +9,7 @@
       manifest?.label
     }}</div>
     <div
-      fxFlex="auto"
+      fxFlex="noshrink"
       fxLayout="row"
       fxLayoutAlign="end center"
       class="buttons-container"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When viewing items with long labels the header buttons overlap each other or overflow on Internet Explorer

Issue Number: N/A

## What is the new behavior?

Buttons do not overflow or overlap

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
