### PR TITLE
fix: cannot read property 'focus' of null

### DIFF
--- a/libs/ngx-mime/src/lib/core/mime-dom-helper.ts
+++ b/libs/ngx-mime/src/lib/core/mime-dom-helper.ts
@@ -34,7 +34,9 @@ export class MimeDomHelper {
 
   public setFocusOnViewer(): void {
     const el:HTMLElement = document.getElementById('mimeViewer');
-    el.focus();
+    if (el) {
+      el.focus();
+    }
   }
 
   private createFullscreenDimensions(el: ElementRef): Dimensions {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

If I open a manifest with an attribution, and then navigation to a view without a viewer. Then the viewer throws an error message.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
```
ERROR TypeError: Cannot read property 'focus' of null
    at e.setFocusOnViewer (11-es2015.add30e383e71a89a3687.js:1)
```

Issue Number: N/A

## What is the new behavior?
The viewer checks if there is an viewer to set focus on. 

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
