### PR TITLE
Fix/highlight rotation

### DIFF
--- a/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.spec.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.spec.ts
@@ -1,9 +1,12 @@
 import { HttpClient, HttpHandler } from '@angular/common/http';
 import { inject, TestBed } from '@angular/core/testing';
 import { MediaObserver } from '@angular/flex-layout';
+import { testManifest } from '../../test/testManifest';
+import { ManifestBuilder } from '../builders/manifest.builder';
 import { ClickService } from '../click-service/click.service';
 import { IiifContentSearchService } from '../iiif-content-search-service/iiif-content-search.service';
 import { MimeResizeService } from '../mime-resize-service/mime-resize.service';
+import { MimeViewerConfig } from '../mime-viewer-config';
 import { Hit } from '../models/hit';
 import { SearchResult } from '../models/search-result';
 import { ViewerLayoutService } from '../viewer-layout-service/viewer-layout-service';
@@ -64,18 +67,24 @@ describe('ViewerService', () => {
   it('should keep state of rotation on destroy when layoutSwitch = true', inject(
     [ViewerService],
     (viewerService: ViewerService) => {
+      let rotation: number;
+      viewerService.onRotationChange.subscribe((serviceRotation: number) => (rotation = serviceRotation));
+      viewerService.setUpViewer(new ManifestBuilder(testManifest).build(), new MimeViewerConfig());
       viewerService.rotate();
       viewerService.destroy(true);
-      expect(viewerService.rotation).toEqual(90);
+      expect(rotation).toEqual(90);
     }
   ));
 
   it('should set rotation to 0 on destroy', inject(
     [ViewerService],
     (viewerService: ViewerService) => {
+      let rotation: number;
+      viewerService.onRotationChange.subscribe((serviceRotation: number) => (rotation = serviceRotation));
+      viewerService.setUpViewer(new ManifestBuilder(testManifest).build(), new MimeViewerConfig());
       viewerService.rotate();
       viewerService.destroy();
-      expect(viewerService.rotation).toEqual(0);
+      expect(rotation).toEqual(0);
     }
   ));
 });

--- a/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.spec.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClient, HttpHandler } from '@angular/common/http';
-import { inject, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
 import { MediaObserver } from '@angular/flex-layout';
 import { testManifest } from '../../test/testManifest';
 import { ManifestBuilder } from '../builders/manifest.builder';
@@ -9,15 +10,27 @@ import { MimeResizeService } from '../mime-resize-service/mime-resize.service';
 import { MimeViewerConfig } from '../mime-viewer-config';
 import { Hit } from '../models/hit';
 import { SearchResult } from '../models/search-result';
+import { ViewerLayout } from '../models/viewer-layout';
 import { ViewerLayoutService } from '../viewer-layout-service/viewer-layout-service';
 import { CanvasService } from './../canvas-service/canvas-service';
 import { ModeService } from './../mode-service/mode.service';
 import { ViewerService } from './viewer.service';
 
+@Component({
+  template: `
+    <div id="openseadragon"></div>
+  `
+})
+class TestHostComponent {}
+
 describe('ViewerService', () => {
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let viewerLayoutService: ViewerLayoutService;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],
+      declarations: [TestHostComponent],
       providers: [
         ViewerService,
         ClickService,
@@ -31,6 +44,11 @@ describe('ViewerService', () => {
         MediaObserver
       ]
     });
+
+    viewerLayoutService = TestBed.inject(ViewerLayoutService);
+    viewerLayoutService.setLayout(ViewerLayout.TWO_PAGE);
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostFixture.detectChanges();
   });
 
   it('should be created', inject(
@@ -64,27 +82,48 @@ describe('ViewerService', () => {
       expect(viewerService.currentSearch).toBeNull();
     }
   ));
-  it('should keep state of rotation on destroy when layoutSwitch = true', inject(
-    [ViewerService],
-    (viewerService: ViewerService) => {
-      let rotation: number;
-      viewerService.onRotationChange.subscribe((serviceRotation: number) => (rotation = serviceRotation));
-      viewerService.setUpViewer(new ManifestBuilder(testManifest).build(), new MimeViewerConfig());
-      viewerService.rotate();
-      viewerService.destroy(true);
-      expect(rotation).toEqual(90);
-    }
-  ));
 
-  it('should set rotation to 0 on destroy', inject(
-    [ViewerService],
-    (viewerService: ViewerService) => {
+  it('should keep state of rotation on destroy when layoutSwitch = true', function(done) {
+    inject([ViewerService], (viewerService: ViewerService) => {
       let rotation: number;
-      viewerService.onRotationChange.subscribe((serviceRotation: number) => (rotation = serviceRotation));
-      viewerService.setUpViewer(new ManifestBuilder(testManifest).build(), new MimeViewerConfig());
-      viewerService.rotate();
-      viewerService.destroy();
-      expect(rotation).toEqual(0);
-    }
-  ));
+      viewerService.onRotationChange.subscribe((serviceRotation: number) => {
+        rotation = serviceRotation;
+      });
+      viewerService.setUpViewer(
+        new ManifestBuilder(testManifest).build(),
+        new MimeViewerConfig()
+      );
+
+      viewerService.onOsdReadyChange.subscribe(state => {
+        if (state) {
+          viewerService.rotate();
+          viewerService.destroy(true);
+          expect(rotation).toEqual(90);
+          done();
+        }
+      });
+    })();
+  });
+
+  it('should set rotation to 0 on destroy', function(done) {
+    inject([ViewerService], (viewerService: ViewerService) => {
+      let rotation: number;
+      viewerService.onRotationChange.subscribe((serviceRotation: number) => {
+        rotation = serviceRotation;
+      });
+      viewerService.setUpViewer(
+        new ManifestBuilder(testManifest).build(),
+        new MimeViewerConfig()
+      );
+
+      viewerService.onOsdReadyChange.subscribe(state => {
+        if (state) {
+          viewerService.rotate();
+          viewerService.destroy();
+          expect(rotation).toEqual(0);
+          done();
+        }
+      });
+    })();
+  });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

ContentSearch hits is placed incorrectly when page is rotated.
Using the hotkey during a rotation redraw it is possible to increase rotation angle causing the viewer to skip over the next expected angle.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #298 

## What is the new behavior?
ContentSearch hits are now correctly placed when page is rotated.
Rotation can only be triggered when the OSD is ready.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

ViewerService.rotation is no longer public, it should not have been public in the first place as it should only be modified by calling ViewerService.rotate()

## Other information
