### PR TITLE
fix: setting default tileOverlap to 0.1

### DIFF
--- a/libs/ngx-mime/src/lib/core/viewer-service/iiif-tile-source-strategy.spec.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/iiif-tile-source-strategy.spec.ts
@@ -20,6 +20,7 @@ describe('IiifTileSourceStrategy ', () => {
     const res = strategy.getTileSource(resource);
 
     expect(res.service.id).toBe('testId');
+    expect(res.tileOverlap).toBe(0.1);
   });
 
   it('should return a complete IIIF Image Api Service uri', () => {

--- a/libs/ngx-mime/src/lib/core/viewer-service/iiif-tile-source-strategy.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/iiif-tile-source-strategy.ts
@@ -6,6 +6,7 @@ export class IiifTileSourceStrategy implements TileSourceStrategy {
     let tileSource: any;
     if (resource.service.service) {
       tileSource = resource.service;
+      tileSource.tileOverlap = 0.1; // Workaround for https://github.com/openseadragon/openseadragon/issues/1722
     } else {
       tileSource = resource.service['@id'];
       tileSource = tileSource.startsWith('//')


### PR DESCRIPTION
This is a workaround for https://github.com/openseadragon/openseadragon/issues/1722

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

There is overlap between tiles

Issue Number: #313 

## What is the new behavior?

Ther is no overlap btween tiles

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
