### PR TITLE
fix: avoid leaking generic css rules

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -12,6 +12,7 @@
         "build": {
           "builder": "@nrwl/angular:package",
           "options": {
+            "allowedCommonJsDependencies": ["openseadragon"],
             "tsConfig": "libs/ngx-mime/tsconfig.lib.json",
             "project": "libs/ngx-mime/ng-package.json",
             "buildableProjectDepsInPackageJsonType": "dependencies"
@@ -32,9 +33,7 @@
               "./node_modules/openseadragon/build/openseadragon/openseadragon.min.js"
             ]
           },
-          "outputs": [
-            "coverage/libs/ngx-mime"
-          ]
+          "outputs": ["coverage/libs/ngx-mime"]
         },
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
@@ -43,10 +42,7 @@
               "libs/ngx-mime/tsconfig.lib.json",
               "libs/ngx-mime/tsconfig.spec.json"
             ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/ngx-mime/**/*"
-            ]
+            "exclude": ["**/node_modules/**", "!libs/ngx-mime/**/*"]
           }
         }
       }
@@ -65,20 +61,15 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
+            "allowedCommonJsDependencies": ["openseadragon"],
             "aot": true,
             "outputPath": "dist/apps/demo",
             "index": "apps/demo/src/index.html",
             "main": "apps/demo/src/main.ts",
             "polyfills": "apps/demo/src/polyfills.ts",
             "tsConfig": "apps/demo/tsconfig.app.json",
-            "assets": [
-              "apps/demo/src/favicon.ico",
-              "apps/demo/src/assets"
-            ],
-            "styles": [
-              "apps/demo/src/styles.scss",
-              "apps/demo/src/theme.scss"
-            ],
+            "assets": ["apps/demo/src/favicon.ico", "apps/demo/src/assets"],
+            "styles": ["apps/demo/src/styles.scss", "apps/demo/src/theme.scss"],
             "scripts": [
               "./node_modules/openseadragon/build/openseadragon/openseadragon.min.js"
             ]
@@ -107,9 +98,7 @@
               "buildOptimizer": true
             }
           },
-          "outputs": [
-            "{options.outputPath}"
-          ]
+          "outputs": ["{options.outputPath}"]
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
@@ -135,20 +124,13 @@
             "polyfills": "apps/demo/src/polyfills.ts",
             "tsConfig": "apps/demo/tsconfig.spec.json",
             "karmaConfig": "apps/demo/karma.conf.js",
-            "styles": [
-              "apps/demo/src/styles.scss"
-            ],
+            "styles": ["apps/demo/src/styles.scss"],
             "scripts": [
               "./node_modules/openseadragon/build/openseadragon/openseadragon.min.js"
             ],
-            "assets": [
-              "apps/demo/src/favicon.ico",
-              "apps/demo/src/assets"
-            ]
+            "assets": ["apps/demo/src/favicon.ico", "apps/demo/src/assets"]
           },
-          "outputs": [
-            "coverage/apps/demo/"
-          ]
+          "outputs": ["coverage/apps/demo/"]
         },
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
@@ -157,10 +139,7 @@
               "apps/demo/tsconfig.app.json",
               "apps/demo/tsconfig.spec.json"
             ],
-            "exclude": [
-              "**/node_modules/**",
-              "!apps/demo/**"
-            ]
+            "exclude": ["**/node_modules/**", "!apps/demo/**"]
           }
         }
       }
@@ -180,10 +159,7 @@
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
             "tsConfig": "apps/demo-e2e/tsconfig.e2e.json",
-            "exclude": [
-              "**/node_modules/**",
-              "!apps/demo-e2e/**"
-            ]
+            "exclude": ["**/node_modules/**", "!apps/demo-e2e/**"]
           }
         }
       }
@@ -202,6 +178,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
+            "allowedCommonJsDependencies": ["openseadragon"],
             "aot": true,
             "outputPath": "dist/apps/integration",
             "index": "apps/integration/src/index.html",
@@ -252,9 +229,7 @@
               "buildOptimizer": true
             }
           },
-          "outputs": [
-            "{options.outputPath}"
-          ]
+          "outputs": ["{options.outputPath}"]
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
@@ -280,9 +255,7 @@
             "polyfills": "apps/integration/src/polyfills.ts",
             "tsConfig": "apps/integration/tsconfig.spec.json",
             "karmaConfig": "apps/integration/karma.conf.js",
-            "styles": [
-              "apps/integration/src/styles.scss"
-            ],
+            "styles": ["apps/integration/src/styles.scss"],
             "scripts": [
               "./node_modules/openseadragon/build/openseadragon/openseadragon.min.js"
             ],
@@ -291,9 +264,7 @@
               "apps/integration/src/assets"
             ]
           },
-          "outputs": [
-            "coverage/apps/integration/"
-          ]
+          "outputs": ["coverage/apps/integration/"]
         },
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
@@ -302,10 +273,7 @@
               "apps/integration/tsconfig.app.json",
               "apps/integration/tsconfig.spec.json"
             ],
-            "exclude": [
-              "**/node_modules/**",
-              "!apps/integration/**"
-            ]
+            "exclude": ["**/node_modules/**", "!apps/integration/**"]
           }
         }
       }
@@ -325,10 +293,7 @@
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
             "tsConfig": "apps/integration-e2e/tsconfig.e2e.json",
-            "exclude": [
-              "**/node_modules/**",
-              "!apps/integration-e2e/**"
-            ]
+            "exclude": ["**/node_modules/**", "!apps/integration-e2e/**"]
           }
         }
       }
@@ -347,6 +312,7 @@
         "build": {
           "builder": "ngx-build-plus:browser",
           "options": {
+            "allowedCommonJsDependencies": ["openseadragon"],
             "outputPath": "dist/apps/elements",
             "index": "apps/elements/src/index.html",
             "main": "apps/elements/src/main.ts",
@@ -420,10 +386,7 @@
               "apps/elements/tsconfig.app.json",
               "apps/elements/tsconfig.spec.json"
             ],
-            "exclude": [
-              "**/node_modules/**",
-              "!apps/elements/**/*"
-            ]
+            "exclude": ["**/node_modules/**", "!apps/elements/**/*"]
           }
         },
         "test": {
@@ -433,9 +396,7 @@
             "polyfills": "apps/elements/src/polyfills.ts",
             "tsConfig": "apps/elements/tsconfig.spec.json",
             "karmaConfig": "apps/elements/karma.conf.js",
-            "styles": [
-              "apps/elements/src/styles.scss"
-            ],
+            "styles": ["apps/elements/src/styles.scss"],
             "scripts": [
               "./node_modules/openseadragon/build/openseadragon/openseadragon.min.js"
             ],
@@ -462,13 +423,8 @@
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
-            "tsConfig": [
-              "apps/elements-e2e/tsconfig.e2e.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!apps/elements-e2e/**/*"
-            ]
+            "tsConfig": ["apps/elements-e2e/tsconfig.e2e.json"],
+            "exclude": ["**/node_modules/**", "!apps/elements-e2e/**/*"]
           }
         }
       }

--- a/apps/elements/src/app/app.component.html
+++ b/apps/elements/src/app/app.component.html
@@ -1,5 +1,4 @@
 <mime-viewer
-  id="mime-viewer"
   [manifestUri]="manifestUri"
   [config]="mimeConfig"
   tabindex="0"

--- a/apps/integration-e2e/pages/content-search.po.ts
+++ b/apps/integration-e2e/pages/content-search.po.ts
@@ -1,5 +1,5 @@
+import { browser, by, element, ElementFinder } from 'protractor';
 import { protractor } from 'protractor/built';
-import { browser, element, ElementFinder, by } from 'protractor';
 import { Utils } from '../helpers/utils';
 
 const utils = new Utils();
@@ -13,13 +13,13 @@ export class ContentSearchPage {
 
   closeButton(): Promise<ElementFinder> {
     return utils.waitForElement(
-      element(by.css('#close-content-search-dialog-button'))
+      element(by.css('.close-content-search-dialog-button'))
     );
   }
 
   async setSearchTerm(term: string) {
     const el: ElementFinder = await utils.waitForElement(
-      element(by.css('.content-search-input'))
+      element(by.css('input.content-search-input'))
     );
     await el.clear();
     await el.sendKeys(term);
@@ -28,14 +28,14 @@ export class ContentSearchPage {
 
   async searchTerm(): Promise<string> {
     const el = await utils.waitForElement(
-      element(by.css('.content-search-input'))
+      element(by.css('input.content-search-input'))
     );
     return el.getText();
   }
 
   async getNumberOfHits() {
     const el: ElementFinder = await utils.waitForPresenceOf(
-      element(by.css('#numberOfHits'))
+      element(by.css('.numberOfHits'))
     );
     const numberOfHits = await el.getAttribute('value');
     return parseInt(numberOfHits, 8);
@@ -53,11 +53,11 @@ export class ContentSearchPage {
   }
 
   contentSearchNavigatorToolbar() {
-    return element(by.css('#content-search-navigator-toolbar'));
+    return element(by.css('.content-search-navigator-toolbar'));
   }
 
   clearInputButton() {
-    return utils.waitForElement(element(by.id('clearSearchButton')));
+    return utils.waitForElement(element(by.css('.clearSearchButton')));
   }
 
   clearButton() {

--- a/apps/integration-e2e/pages/contents-dialog.po.ts
+++ b/apps/integration-e2e/pages/contents-dialog.po.ts
@@ -1,4 +1,4 @@
-import { element, by } from 'protractor';
+import { by, element } from 'protractor';
 import { Utils } from '../helpers/utils';
 
 const utils = new Utils();

--- a/apps/integration-e2e/pages/metadata.po.ts
+++ b/apps/integration-e2e/pages/metadata.po.ts
@@ -33,7 +33,7 @@ export class MetadataPage {
       metadatas.push(
         new Metadata({
           title: title,
-          content: content
+          content: content,
         })
       );
     }
@@ -41,12 +41,12 @@ export class MetadataPage {
   }
 
   getAttribution() {
-    const el = element(by.css('#metadata-attribution'));
+    const el = element(by.css('.content.attribution'));
     return utils.waitForElement(el);
   }
 
   getLicense() {
-    const el = element(by.css('#metadata-license'));
+    const el = element(by.css('.content.license'));
     return utils.waitForElement(el);
   }
 

--- a/apps/integration-e2e/pages/viewer.po.ts
+++ b/apps/integration-e2e/pages/viewer.po.ts
@@ -24,7 +24,7 @@ export class ViewerPage {
     'a-individuals-manifest':
       'http://localhost:4040/catalog/v1/iiif/a-individuals-manifest/manifest',
     'a-non-attribution-manifest':
-      'http://localhost:4040/catalog/v1/iiif/a-non-attribution-manifest/manifest'
+      'http://localhost:4040/catalog/v1/iiif/a-non-attribution-manifest/manifest',
   };
 
   private isElements = false;
@@ -94,7 +94,7 @@ export class ViewerPage {
 
   async slideToCanvasGroup(canvasGroupIndex: number) {
     const slider = await utils.waitForElement(
-      element(by.css('#navigationSlider'))
+      element(by.css('.navigation-slider'))
     );
     const isTwoPageView = this.isTwoPageView();
     if ((await isTwoPageView) && canvasGroupIndex > 1) {
@@ -108,12 +108,12 @@ export class ViewerPage {
 
   async goToCanvasGroupWithDialog(canvasGroupIndex: number) {
     const goToCanvasGroupButton = await utils.waitForElement(
-      element(by.css('#goToCanvasGroupButton'))
+      element(by.css('button.canvasGroups'))
     );
     await goToCanvasGroupButton.click();
     const isTwoPageView = this.isTwoPageView();
     const input = await utils.waitForElement(
-      element(by.css('#goToCanvasGroupInput'))
+      element(by.css('.go-to-canvas-group-input'))
     );
     await input.sendKeys(canvasGroupIndex);
     await input.sendKeys(protractor.Key.ENTER);
@@ -155,40 +155,39 @@ export class ViewerPage {
   }
 
   async openContentsDialog() {
-    await element(by.css('#contentsDialogButton')).click();
+    await element(by.css('#ngx-mimeContentsDialogButton')).click();
     await utils.waitForElement(element(by.css('.contents-container')));
     await browser.sleep(2000);
   }
 
   async openHelpDialog() {
-    await element(by.css('#helpDialogButton')).click();
+    await element(by.css('#ngx-mimeHelpDialogButton')).click();
     await utils.waitForElement(element(by.css('.help-container')));
     await browser.sleep(2000);
   }
 
   async openTableOfContentsTab() {
-    await element
-      .all(by.css('.mat-tab-label'))
-      .get(1)
-      .click();
-    await utils.waitForElement(element(by.css('.toc-container')));
+    await element.all(by.css('.mat-tab-label')).get(1).click();
+    await utils.waitForElement(element(by.css('.ngx-mime-toc-container')));
     await this.waitForAnimation();
   }
 
   async openContentSearchDialog() {
-    const contentSearchDialogButton: ElementFinder = await utils.waitForElement(
-      element(by.css('#contentSearchDialogButton'))
+    const ngxmimeContentSearchDialogButton: ElementFinder = await utils.waitForElement(
+      element(by.css('#ngx-mimeContentSearchDialogButton'))
     );
-    await contentSearchDialogButton.click();
-    await utils.waitForElement(element(by.css('#content-search-form-submit')));
+    await ngxmimeContentSearchDialogButton.click();
+    await utils.waitForElement(
+      element(by.css('.content-search-box button[type="submit"]'))
+    );
     await this.waitForAnimation();
   }
 
   async fullscreenButton(): Promise<ElementFinder> {
-    const fullscreenButton: ElementFinder = await utils.waitForElement(
-      element(by.css('#fullscreenButton'))
+    const ngxmimeFullscreenButton: ElementFinder = await utils.waitForElement(
+      element(by.css('#ngx-mimeFullscreenButton'))
     );
-    return fullscreenButton;
+    return ngxmimeFullscreenButton;
   }
 
   openSeadragonElement() {
@@ -197,7 +196,7 @@ export class ViewerPage {
   }
 
   getAttribution() {
-    const el = element(by.css('#attribution-container > .mat-dialog-content'));
+    const el = element(by.css('.attribution-container > .mat-dialog-content'));
     return utils.waitForElement(el);
   }
 
@@ -293,7 +292,7 @@ export class ViewerPage {
 
   getAnimationTimeInMs(): Promise<number> {
     return new Promise((resolve, reject) => {
-      this.getAnimationTimeInSec().then(time => {
+      this.getAnimationTimeInSec().then((time) => {
         resolve(time * 1000);
       });
     });
@@ -379,11 +378,7 @@ export class ViewerPage {
     await browser
       .findElement(By.css('.openseadragon-canvas > canvas'))
       .then((canvas: WebElement) => {
-        return browser
-          .touchActions()
-          .tap(canvas)
-          .tap(canvas)
-          .perform();
+        return browser.touchActions().tap(canvas).tap(canvas).perform();
       });
   }
 
@@ -529,7 +524,7 @@ export class ViewerPage {
 
     const [leftCanvasGroupMask, rightCanvasGroupMask] = await Promise.all([
       this.getLeftCanvasGroupMask(),
-      this.getRightCanvasGroupMask()
+      this.getRightCanvasGroupMask(),
     ]);
 
     const leftCanvasGroupMaskSize = await leftCanvasGroupMask.getSize();
@@ -572,7 +567,7 @@ export class ViewerPage {
       lastEvent = 'elementCalculatedLocastion';
       const elementCalculatedLocastion = {
         left: elementLocation.x,
-        right: elementLocation.x + elementSize.width
+        right: elementLocation.x + elementSize.width,
       };
       lastEvent = 'return';
       return (

--- a/apps/integration-e2e/step-definitions/access-keys.steps.ts
+++ b/apps/integration-e2e/step-definitions/access-keys.steps.ts
@@ -1,10 +1,9 @@
 const { Given, Then } = require('cucumber');
 const { expect } = require('chai');
 
-import { ViewerPage } from '../pages/viewer.po';
-import { browser } from 'protractor';
 import { ContentSearchPage } from '../pages/content-search.po';
 import { ContentsDialogPage } from '../pages/contents-dialog.po';
+import { ViewerPage } from '../pages/viewer.po';
 
 const page = new ViewerPage();
 const contentSearchPage = new ContentSearchPage();

--- a/apps/integration-e2e/step-definitions/browse.steps.ts
+++ b/apps/integration-e2e/step-definitions/browse.steps.ts
@@ -2,7 +2,6 @@ const { When, Then } = require('cucumber');
 const { expect } = require('chai');
 
 import { ViewerPage } from './../pages/viewer.po';
-import { MetadataPage } from './../pages/metadata.po';
 
 const page = new ViewerPage();
 
@@ -12,11 +11,11 @@ When(
     if (direction === 'left-to-right') {
       const start = {
         x: 200,
-        y: 0
+        y: 0,
       };
       const end = {
         x: 0,
-        y: 0
+        y: 0,
       };
       await page.swipe(start, end);
     }

--- a/apps/integration-e2e/step-definitions/content-dialog.steps.ts
+++ b/apps/integration-e2e/step-definitions/content-dialog.steps.ts
@@ -1,11 +1,10 @@
 const { Given, When, Then } = require('cucumber');
 const { expect } = require('chai');
 import { browser } from 'protractor';
-
-import { ViewerPage } from '../pages/viewer.po';
 import { ContentsPage } from '../pages/contents.po';
 import { MetadataPage } from '../pages/metadata.po';
 import { TableOfContentsPage } from '../pages/table-of-contents.po';
+import { ViewerPage } from '../pages/viewer.po';
 
 const page = new ViewerPage();
 const contents = new ContentsPage();
@@ -42,7 +41,7 @@ Then('the viewer should go to page {word}', async (pageNumber: string) => {
   expect(currentCanvasGroupString.includes(pageNumber)).to.eql(true);
 });
 
-Then('the Contents dialog should be {word}', async state => {
+Then('the Contents dialog should be {word}', async (state) => {
   const isOpen = await contents.isOpen();
   const expectedState = state === 'closed' ? false : true;
   expect(isOpen).to.equal(expectedState);

--- a/apps/integration-e2e/step-definitions/content-search.steps.ts
+++ b/apps/integration-e2e/step-definitions/content-search.steps.ts
@@ -1,8 +1,8 @@
 const { Given, When, Then } = require('cucumber');
 const { expect } = require('chai');
 
+import { ViewerPage } from '../pages/viewer.po';
 import { ContentSearchPage } from './../pages/content-search.po';
-import { ViewerPage, Point } from '../pages/viewer.po';
 
 const page = new ViewerPage();
 const contentSearchPage = new ContentSearchPage();
@@ -68,7 +68,7 @@ Then('the word {string} should be highlighted', async (term: string) => {
   expect(firstHit).to.contains(`${term} </em>`);
 });
 
-Then('the page with hit number {word} should be displayed', async hit => {
+Then('the page with hit number {word} should be displayed', async (hit) => {
   const currentPageString = await page.getCurrentCanvasGroupLabel();
   if (hit === 1) {
     expect(currentPageString.includes('25')).to.eql(true);

--- a/apps/integration-e2e/step-definitions/fullscreen.steps.ts
+++ b/apps/integration-e2e/step-definitions/fullscreen.steps.ts
@@ -1,8 +1,8 @@
 const { Given, When, Then } = require('cucumber');
 const { expect } = require('chai');
 
-import { ViewerPage } from './../pages/viewer.po';
 import { MetadataPage } from './../pages/metadata.po';
+import { ViewerPage } from './../pages/viewer.po';
 
 const page = new ViewerPage();
 const metadata = new MetadataPage();

--- a/apps/integration-e2e/step-definitions/help-dialog.steps.ts
+++ b/apps/integration-e2e/step-definitions/help-dialog.steps.ts
@@ -1,7 +1,7 @@
 import { Given, Then } from 'cucumber';
-const { expect } = require('chai');
 import { HelpDialogPage } from '../pages/help-dialog.po';
 import { ViewerPage } from '../pages/viewer.po';
+const { expect } = require('chai');
 
 const page = new ViewerPage();
 const help = new HelpDialogPage();
@@ -15,7 +15,7 @@ Then('help is displayed to the user', async () => {
   expect(isOpen).to.equal(true);
 });
 
-Then('the Help dialog should be {word}', async state => {
+Then('the Help dialog should be {word}', async (state) => {
   const isOpen = await help.isOpen();
   const expectedState = state === 'closed' ? false : true;
   expect(isOpen).to.equal(expectedState);

--- a/apps/integration-e2e/step-definitions/layout.steps.ts
+++ b/apps/integration-e2e/step-definitions/layout.steps.ts
@@ -1,9 +1,7 @@
 const { Given, Then } = require('cucumber');
 const { expect } = require('chai');
-import { browser, by } from 'protractor';
-
-import { ViewerPage } from '../pages/viewer.po';
 import { Utils } from '../helpers/utils';
+import { ViewerPage } from '../pages/viewer.po';
 
 const page = new ViewerPage();
 const utils = new Utils();
@@ -16,7 +14,6 @@ Given('the layout is two-page', async () => {
 
   expect(await page.isTwoPageView()).to.equal(true);
 });
-
 
 Given('the layout is one-page', async () => {
   await page.setDashboardMode();

--- a/apps/integration-e2e/step-definitions/logo.steps.ts
+++ b/apps/integration-e2e/step-definitions/logo.steps.ts
@@ -1,8 +1,8 @@
 const { Then } = require('cucumber');
 const { expect } = require('chai');
 
-import { ViewerPage } from './../pages/viewer.po';
 import { MetadataPage } from './../pages/metadata.po';
+import { ViewerPage } from './../pages/viewer.po';
 
 const viewer = new ViewerPage();
 const metadata = new MetadataPage();

--- a/apps/integration-e2e/step-definitions/pan.steps.ts
+++ b/apps/integration-e2e/step-definitions/pan.steps.ts
@@ -1,7 +1,7 @@
 const { When, Then } = require('cucumber');
 const { expect } = require('chai');
 
-import { ViewerPage, Point } from '../pages/viewer.po';
+import { Point, ViewerPage } from '../pages/viewer.po';
 
 const page = new ViewerPage();
 let previousCenter: Point;

--- a/apps/integration-e2e/step-definitions/rights-notices.steps.ts
+++ b/apps/integration-e2e/step-definitions/rights-notices.steps.ts
@@ -1,8 +1,8 @@
 const { Given, When, Then } = require('cucumber');
 const { expect } = require('chai');
 
-import { ViewerPage } from './../pages/viewer.po';
 import { MetadataPage } from './../pages/metadata.po';
+import { ViewerPage } from './../pages/viewer.po';
 
 const viewer = new ViewerPage();
 const metadata = new MetadataPage();

--- a/apps/integration-e2e/step-definitions/view-switch.steps.ts
+++ b/apps/integration-e2e/step-definitions/view-switch.steps.ts
@@ -1,9 +1,7 @@
 const { Given, When, Then } = require('cucumber');
 const { expect } = require('chai');
-import { browser, by } from 'protractor';
-
-import { ViewerPage } from '../pages/viewer.po';
 import { Utils } from '../helpers/utils';
+import { ViewerPage } from '../pages/viewer.po';
 
 const page = new ViewerPage();
 const utils = new Utils();

--- a/apps/integration-e2e/step-definitions/viewer-page.steps.ts
+++ b/apps/integration-e2e/step-definitions/viewer-page.steps.ts
@@ -1,8 +1,7 @@
-import { Given, When, Then } from 'cucumber';
 import { expect } from 'chai';
-
-import { ViewerPage } from '../pages/viewer.po';
+import { Given, Then, When } from 'cucumber';
 import { ElementsPage } from '../pages/elements.po';
+import { ViewerPage } from '../pages/viewer.po';
 
 const viewerPage = new ViewerPage();
 const elementsPage = new ElementsPage();

--- a/apps/integration/src/app/viewer/components/viewer/viewer.component.html
+++ b/apps/integration/src/app/viewer/components/viewer/viewer.component.html
@@ -1,5 +1,4 @@
 <mime-viewer
-  id="mime-viewer"
   [manifestUri]="manifestUri"
   tabindex="0"
 ></mime-viewer>

--- a/libs/ngx-mime/src/lib/attribution-dialog/attribution-dialog.component.html
+++ b/libs/ngx-mime/src/lib/attribution-dialog/attribution-dialog.component.html
@@ -1,4 +1,4 @@
-<div #container id="attribution-container" class="attribution-container">
+<div #container class="attribution-container">
   <mat-toolbar class="attribution-toolbar">
     <div fxLayout="row" fxLayoutAlign="space-between center" fxFlex>
       <h1 mat-dialog-title>{{ intl.attributionLabel }}</h1>

--- a/libs/ngx-mime/src/lib/canvas-group-dialog/canvas-group-dialog.component.html
+++ b/libs/ngx-mime/src/lib/canvas-group-dialog/canvas-group-dialog.component.html
@@ -8,25 +8,20 @@
   >
     <mat-form-field [floatLabel]="'always'">
       <input
-        id="goToCanvasGroupInput"
+        class="go-to-canvas-group-input"
         type="number"
         matInput
         min="1"
         [placeholder]="intl.enterPageNumber"
         formControlName="canvasGroupControl"
       />
-      <mat-error
-        id="canvasGroupDoesNotExistsError"
-        *ngIf="canvasGroupControl.errors?.max"
-        >{{ intl.pageDoesNotExists }}</mat-error
-      >
+      <mat-error *ngIf="canvasGroupControl.errors?.max">{{
+        intl.pageDoesNotExists
+      }}</mat-error>
     </mat-form-field>
     <div fxLayout="row" fxLayoutAlign="end center">
-      <button id="cancelButton" type="button" mat-button matDialogClose>
-        CANCEL
-      </button>
+      <button type="button" mat-button matDialogClose> CANCEL </button>
       <button
-        id="goToCanvasGroupSubmitButton"
         type="submit"
         mat-button
         [disabled]="canvasGroupForm.pristine || canvasGroupForm.invalid"

--- a/libs/ngx-mime/src/lib/canvas-group-dialog/canvas-group-dialog.component.spec.ts
+++ b/libs/ngx-mime/src/lib/canvas-group-dialog/canvas-group-dialog.component.spec.ts
@@ -1,5 +1,14 @@
-import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import {
+  ComponentFixture,
+  fakeAsync,
+  flush,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldHarness } from '@angular/material/form-field/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { injectedStub } from '../../testing/injected-stub';
@@ -19,32 +28,38 @@ import { CanvasGroupDialogComponent } from './canvas-group-dialog.component';
 describe('PageDialogComponent', () => {
   let component: CanvasGroupDialogComponent;
   let fixture: ComponentFixture<CanvasGroupDialogComponent>;
+  let loader: HarnessLoader;
+
   let intl: MimeViewerIntl;
   let canvasService: CanvasServiceStub;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, SharedModule],
-      declarations: [CanvasGroupDialogComponent],
-      providers: [
-        ViewerService,
-        ClickService,
-        ModeService,
-        ViewerLayoutService,
-        MimeViewerIntl,
-        {
-          provide: IiifContentSearchService,
-          useClass: IiifContentSearchServiceStub
-        },
-        { provide: MatDialogRef, useClass: MatDialogRefStub },
-        { provide: CanvasService, useClass: CanvasServiceStub }
-      ]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [NoopAnimationsModule, SharedModule],
+        declarations: [CanvasGroupDialogComponent],
+        providers: [
+          ViewerService,
+          ClickService,
+          ModeService,
+          ViewerLayoutService,
+          MimeViewerIntl,
+          {
+            provide: IiifContentSearchService,
+            useClass: IiifContentSearchServiceStub,
+          },
+          { provide: MatDialogRef, useClass: MatDialogRefStub },
+          { provide: CanvasService, useClass: CanvasServiceStub },
+        ],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CanvasGroupDialogComponent);
     component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+
     intl = TestBed.inject(MimeViewerIntl);
     canvasService = injectedStub(CanvasService);
     fixture.detectChanges();
@@ -67,7 +82,7 @@ describe('PageDialogComponent', () => {
   });
 
   describe('error messages', () => {
-    it('should show a error message if user enters a canvas group number index that does not exists', fakeAsync(() => {
+    it('should show a error message if user enters a canvas group number index that does not exists', fakeAsync(async () => {
       canvasService._currentNumberOfCanvasGroups.next(10);
 
       component.canvasGroupControl.setValue(11);
@@ -76,10 +91,10 @@ describe('PageDialogComponent', () => {
       fixture.detectChanges();
       flush();
 
-      const canvasGroupDoesNotExistsError = fixture.debugElement.query(
-        By.css('#canvasGroupDoesNotExistsError')
+      const canvasGroupDoesNotExistsError = await loader.getHarness(
+        MatFormFieldHarness
       );
-      expect(canvasGroupDoesNotExistsError).not.toBeNull();
+      expect(await canvasGroupDoesNotExistsError.hasErrors()).toBeTrue();
     }));
   });
 });

--- a/libs/ngx-mime/src/lib/content-search-dialog/content-search-dialog.component.html
+++ b/libs/ngx-mime/src/lib/content-search-dialog/content-search-dialog.component.html
@@ -4,8 +4,8 @@
       <mat-toolbar color="primary">
         <div fxLayout="row" fxLayoutAlign="start center">
           <button
-            id="close-content-search-dialog-button"
             mat-icon-button
+            class="close-content-search-dialog-button"
             [aria-label]="intl.closeLabel"
             [matTooltip]="intl.closeLabel"
             [matDialogClose]="true"
@@ -19,10 +19,12 @@
     <div *ngSwitchDefault>
       <mat-toolbar>
         <div fxLayout="row" fxLayoutAlign="space-between center" fxFlex>
-          <div mat-dialog-title class="heading heading-desktop">{{ intl.searchLabel }}</div>
+          <div mat-dialog-title class="heading heading-desktop">{{
+            intl.searchLabel
+          }}</div>
           <button
-            id="close-content-search-dialog-button"
             mat-icon-button
+            class="close-content-search-dialog-button"
             [aria-label]="intl.closeLabel"
             [matTooltip]="intl.closeLabel"
             [matDialogClose]="true"
@@ -38,7 +40,6 @@
       <form (ngSubmit)="onSubmit($event)" #searchForm="ngForm">
         <mat-form-field class="content-search-box">
           <button
-            id="content-search-form-submit"
             type="submit"
             matPrefix
             mat-icon-button
@@ -53,14 +54,14 @@
             matInput
             class="content-search-input"
             [(ngModel)]="q"
+            [attr.aria-label]="intl.searchLabel"
             name="q"
             autocomplete="off"
-            aria-labelledby="content-search-form-submit"
           />
           <button
             *ngIf="q"
-            id="clearSearchButton"
             type="button"
+            class="clearSearchButton"
             matSuffix
             mat-icon-button
             [attr.aria-label]="intl.clearSearchLabel"
@@ -78,7 +79,7 @@
       [ngStyle]="tabHeight"
     >
       <div *ngIf="!isSearching" class="content-search-result" fxLayout="column">
-        <input type="hidden" id="numberOfHits" [value]="numberOfHits" />
+        <input type="hidden" class="numberOfHits" [value]="numberOfHits" />
         <div *ngIf="currentSearch && currentSearch.length > 0">
           <div
             *ngIf="numberOfHits > 0"

--- a/libs/ngx-mime/src/lib/content-search-dialog/content-search-dialog.component.spec.ts
+++ b/libs/ngx-mime/src/lib/content-search-dialog/content-search-dialog.component.spec.ts
@@ -1,7 +1,10 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MediaObserver } from '@angular/flex-layout';
+import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -26,41 +29,49 @@ import { ContentSearchDialogComponent } from './content-search-dialog.component'
 describe('ContentSearchDialogComponent', () => {
   let component: ContentSearchDialogComponent;
   let fixture: ComponentFixture<ContentSearchDialogComponent>;
+  let loader: HarnessLoader;
+
   let iiifContentSearchServiceStub: IiifContentSearchServiceStub;
   let iiifManifestServiceStub: IiifManifestServiceStub;
   let mediaObserver: any;
   let dialogRef: any;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, SharedModule, HttpClientTestingModule],
-      declarations: [ContentSearchDialogComponent],
-      providers: [
-        MimeViewerIntl,
-        MimeResizeService,
-        MimeDomHelper,
-        FullscreenService,
-        { provide: MatDialogRef, useClass: MatDialogRefStub },
-        { provide: ViewerService, useClass: ViewerServiceStub },
-        { provide: IiifManifestService, useClass: IiifManifestServiceStub },
-        {
-          provide: IiifContentSearchService,
-          useClass: IiifContentSearchServiceStub
-        }
-      ]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [NoopAnimationsModule, SharedModule, HttpClientTestingModule],
+        declarations: [ContentSearchDialogComponent],
+        providers: [
+          MimeViewerIntl,
+          MimeResizeService,
+          MimeDomHelper,
+          FullscreenService,
+          { provide: MatDialogRef, useClass: MatDialogRefStub },
+          { provide: ViewerService, useClass: ViewerServiceStub },
+          { provide: IiifManifestService, useClass: IiifManifestServiceStub },
+          {
+            provide: IiifContentSearchService,
+            useClass: IiifContentSearchServiceStub,
+          },
+        ],
+      }).compileComponents();
+    })
+  );
 
-  beforeEach(waitForAsync(() => {
-    fixture = TestBed.createComponent(ContentSearchDialogComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(
+    waitForAsync(() => {
+      fixture = TestBed.createComponent(ContentSearchDialogComponent);
+      component = fixture.componentInstance;
+      loader = TestbedHarnessEnvironment.loader(fixture);
 
-    iiifContentSearchServiceStub = injectedStub(IiifContentSearchService);
-    iiifManifestServiceStub = injectedStub(IiifManifestService);
-    mediaObserver = TestBed.inject(MediaObserver);
-    dialogRef = TestBed.inject(MatDialogRef);
-  }));
+      fixture.detectChanges();
+
+      iiifContentSearchServiceStub = injectedStub(IiifContentSearchService);
+      iiifManifestServiceStub = injectedStub(IiifManifestService);
+      mediaObserver = TestBed.inject(MediaObserver);
+      dialogRef = TestBed.inject(MatDialogRef);
+    })
+  );
 
   it('should be created', () => {
     expect(component).toBeTruthy();
@@ -96,8 +107,8 @@ describe('ContentSearchDialogComponent', () => {
     component.hits = [
       new Hit({
         index: 0,
-        match: 'querystring'
-      })
+        match: 'querystring',
+      }),
     ];
     component.numberOfHits = 1;
     fixture.detectChanges();
@@ -118,8 +129,8 @@ describe('ContentSearchDialogComponent', () => {
     component.hits = [
       new Hit({
         index: 0,
-        match: 'querystring'
-      })
+        match: 'querystring',
+      }),
     ];
     component.numberOfHits = 1;
     fixture.detectChanges();
@@ -173,7 +184,7 @@ describe('ContentSearchDialogComponent', () => {
 
     iiifContentSearchServiceStub._currentSearchResult.next(
       new SearchResult({
-        hits: [new Hit(), new Hit()]
+        hits: [new Hit(), new Hit()],
       })
     );
 
@@ -182,22 +193,23 @@ describe('ContentSearchDialogComponent', () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  it('should only show clear button on input', () => {
+  it('should only show clear button on input', async () => {
     const searchInput: DebugElement = fixture.debugElement.query(
       By.css('.content-search-input')
     );
 
-    expect(getClearButton()).toBeNull();
+    expect(await getButtonCount()).toEqual(2);
 
     searchInput.nativeElement.value = 'dummyvalue';
     searchInput.nativeElement.dispatchEvent(new Event('input'));
 
     fixture.detectChanges();
 
-    expect(getClearButton()).not.toBeNull();
+    expect(await getButtonCount()).toBe(3);
   });
 
-  function getClearButton() {
-    return fixture.debugElement.query(By.css('#clearSearchButton'));
+  async function getButtonCount() {
+    const buttons = await loader.getAllHarnesses(MatButtonHarness);
+    return buttons.length;
   }
 });

--- a/libs/ngx-mime/src/lib/contents-dialog/metadata/metadata.component.html
+++ b/libs/ngx-mime/src/lib/contents-dialog/metadata/metadata.component.html
@@ -1,4 +1,4 @@
-<div id="metadata-container" class="metadata-container">
+<div class="ngx-mime-metadata-container">
   <div *ngFor="let metadata of manifest?.metadata" class="metadata">
     <div class="title">{{ metadata.label }}</div>
     <span class="content" [innerHTML]="metadata.value"></span>
@@ -6,22 +6,19 @@
   <div *ngIf="manifest?.attribution">
     <div class="title">{{ intl.attributionLabel }}</div>
     <span
-      id="metadata-attribution"
       class="content attribution"
       [innerHTML]="manifest?.attribution"
     ></span>
   </div>
   <div *ngIf="manifest?.license">
     <div class="title">{{ intl.licenseLabel }}</div>
-    <span id="metadata-license" class="content license"
+    <span class="content license"
       ><a [href]="manifest?.license" target="_blank">{{
         manifest?.license
       }}</a></span
     >
   </div>
   <div *ngIf="manifest?.logo">
-    <span id="metadata-logo"
-      ><img class="content logo" [src]="manifest?.logo"
-    /></span>
+    <span><img class="content logo" [src]="manifest?.logo" /></span>
   </div>
 </div>

--- a/libs/ngx-mime/src/lib/contents-dialog/metadata/metadata.component.spec.ts
+++ b/libs/ngx-mime/src/lib/contents-dialog/metadata/metadata.component.spec.ts
@@ -15,16 +15,18 @@ describe('MetadataComponent', () => {
   let fixture: ComponentFixture<MetadataComponent>;
   let iiifManifestService: IiifManifestServiceStub;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule, HttpClientModule],
-      declarations: [MetadataComponent],
-      providers: [
-        MimeViewerIntl,
-        { provide: IiifManifestService, useClass: IiifManifestServiceStub }
-      ]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SharedModule, HttpClientModule],
+        declarations: [MetadataComponent],
+        providers: [
+          MimeViewerIntl,
+          { provide: IiifManifestService, useClass: IiifManifestServiceStub },
+        ],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MetadataComponent);
@@ -42,8 +44,8 @@ describe('MetadataComponent', () => {
       new Manifest({
         metadata: [
           new Metadata('label1', 'value1'),
-          new Metadata('label2', 'value2')
-        ]
+          new Metadata('label2', 'value2'),
+        ],
       })
     );
     fixture.detectChanges();
@@ -57,7 +59,7 @@ describe('MetadataComponent', () => {
   it('should display attribution', () => {
     iiifManifestService._currentManifest.next(
       new Manifest({
-        attribution: 'This is a test attribution'
+        attribution: 'This is a test attribution',
       })
     );
     fixture.detectChanges();
@@ -73,7 +75,7 @@ describe('MetadataComponent', () => {
   it('should display license', () => {
     iiifManifestService._currentManifest.next(
       new Manifest({
-        license: 'https://wiki.creativecommons.org/wiki/CC0'
+        license: 'https://wiki.creativecommons.org/wiki/CC0',
       })
     );
     fixture.detectChanges();
@@ -89,7 +91,7 @@ describe('MetadataComponent', () => {
   it('should display logo', () => {
     iiifManifestService._currentManifest.next(
       new Manifest({
-        logo: 'http://example.com/dummylogo.jpg'
+        logo: 'http://example.com/dummylogo.jpg',
       })
     );
     fixture.detectChanges();

--- a/libs/ngx-mime/src/lib/contents-dialog/metadata/metadata.component.theme.scss
+++ b/libs/ngx-mime/src/lib/contents-dialog/metadata/metadata.component.theme.scss
@@ -3,12 +3,12 @@
   $foreground: map-get($theme, foreground);
   $accent: map-get($theme, accent);
 
-  #metadata-container .content {
-    color: mat-color($foreground, secondary-text);
+  .ngx-mime-metadata-container {
+    .content {
+      color: mat-color($foreground, secondary-text);
+    }
+    a {
+      color: mat-color($accent);
+    }
   }
-
-  #metadata-container a {
-    color: mat-color($accent);
-  }
-
 }

--- a/libs/ngx-mime/src/lib/contents-dialog/table-of-contents/table-of-contents.component.html
+++ b/libs/ngx-mime/src/lib/contents-dialog/table-of-contents/table-of-contents.component.html
@@ -1,4 +1,4 @@
-<div id="toc-container" class="toc-container">
+<div class="ngx-mime-toc-container">
   <div *ngFor="let structure of manifest?.structures">
     <a
       href=""

--- a/libs/ngx-mime/src/lib/contents-dialog/table-of-contents/table-of-contents.component.spec.ts
+++ b/libs/ngx-mime/src/lib/contents-dialog/table-of-contents/table-of-contents.component.spec.ts
@@ -23,20 +23,22 @@ describe('TocComponent', () => {
   let mediaObserver: any;
   let viewerService: ViewerService;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule, HttpClientModule],
-      declarations: [TocComponent],
-      providers: [
-        ClickService,
-        CanvasService,
-        ModeService,
-        MimeViewerIntl,
-        { provide: IiifManifestService, useClass: IiifManifestServiceStub },
-        { provide: ViewerService, useClass: ViewerServiceStub }
-      ]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SharedModule, HttpClientModule],
+        declarations: [TocComponent],
+        providers: [
+          ClickService,
+          CanvasService,
+          ModeService,
+          MimeViewerIntl,
+          { provide: IiifManifestService, useClass: IiifManifestServiceStub },
+          { provide: ViewerService, useClass: ViewerServiceStub },
+        ],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TocComponent);
@@ -53,27 +55,27 @@ describe('TocComponent', () => {
               { id: 'canvas2' },
               { id: 'canvas3' },
               { id: 'canvas4' },
-              { id: 'canvas5' }
-            ]
-          }
+              { id: 'canvas5' },
+            ],
+          },
         ],
         structures: [
           new Structure({
             label: 'Forside',
             canvases: ['canvas1'],
-            canvasIndex: 0
+            canvasIndex: 0,
           }),
           new Structure({
             label: 'Tittelside',
             canvases: ['canvas2'],
-            canvasIndex: 1
+            canvasIndex: 1,
           }),
           new Structure({
             label: 'Bakside',
             canvases: ['canvas5'],
-            canvasIndex: 4
-          })
-        ]
+            canvasIndex: 4,
+          }),
+        ],
       })
     );
     mediaObserver = TestBed.inject(MediaObserver);
@@ -118,7 +120,7 @@ describe('TocComponent', () => {
     const divs: DebugElement[] = fixture.debugElement.queryAll(
       By.css('.toc-link')
     );
-    divs[2].triggerEventHandler('click', new Event("fakeEvent"));
+    divs[2].triggerEventHandler('click', new Event('fakeEvent'));
 
     expect(viewerService.goToCanvas).toHaveBeenCalledWith(4, false);
   });

--- a/libs/ngx-mime/src/lib/contents-dialog/table-of-contents/table-of-contents.component.theme.scss
+++ b/libs/ngx-mime/src/lib/contents-dialog/table-of-contents/table-of-contents.component.theme.scss
@@ -3,7 +3,7 @@
 @mixin table-of-contents-theme($theme) {
   $foreground: map-get($theme, foreground);
 
-  #toc-container {
+  .ngx-mime-toc-container {
     .canvasGroupIndex {
       color: mat-color($foreground, text);
     }

--- a/libs/ngx-mime/src/lib/core/mime-dom-helper.ts
+++ b/libs/ngx-mime/src/lib/core/mime-dom-helper.ts
@@ -26,14 +26,14 @@ export class MimeDomHelper {
   }
 
   public toggleFullscreen(): void {
-    const el = <any>document.getElementById('mimeViewer');
+    const el = <any>document.getElementById('ngx-mime-mimeViewer');
     if (this.fullscreen.isEnabled()) {
       this.fullscreen.toggle(el);
     }
   }
 
   public setFocusOnViewer(): void {
-    const el: HTMLElement = document.getElementById('mimeViewer');
+    const el: HTMLElement = document.getElementById('ngx-mime-mimeViewer');
     if (el) {
       el.focus();
     }

--- a/libs/ngx-mime/src/lib/help-dialog/help-dialog.component.html
+++ b/libs/ngx-mime/src/lib/help-dialog/help-dialog.component.html
@@ -1,26 +1,22 @@
-<div id="help-container" class="help-container">
+<div class="help-container">
   <div [ngSwitch]="mediaObserver.isActive('lt-md')">
     <div *ngSwitchCase="true">
       <mat-toolbar color="primary">
         <div fxLayout="row" fxLayoutAlign="start center">
-          <button
-            mat-icon-button
-            [matDialogClose]="true"
-          >
+          <button mat-icon-button [matDialogClose]="true">
             <mat-icon>close</mat-icon>
           </button>
-          <h1 mat-dialog-title>{{intl.help.helpLabel}}</h1>
+          <h1 mat-dialog-title>{{ intl.help.helpLabel }}</h1>
         </div>
       </mat-toolbar>
     </div>
     <div *ngSwitchDefault>
       <mat-toolbar>
         <div fxLayout="row" fxLayoutAlign="space-between center" fxFlex>
-          <h1 class="heading-desktop" mat-dialog-title>{{intl.help.helpLabel}}</h1>
-          <button
-            mat-icon-button
-            [matDialogClose]="true"
-          >
+          <h1 class="heading-desktop" mat-dialog-title>{{
+            intl.help.helpLabel
+          }}</h1>
+          <button mat-icon-button [matDialogClose]="true">
             <mat-icon>close</mat-icon>
           </button>
         </div>

--- a/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.html
+++ b/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.html
@@ -2,7 +2,6 @@
   <div fxLayout="row" fxFlex fxLayoutAlign="start center">
     <div fxFlex>
       <mat-slider
-        id="navigationSlider"
         class="navigation-slider"
         [invert]="!invert"
         [max]="numberOfCanvasGroups - 1"
@@ -13,12 +12,7 @@
         fxFlex
       ></mat-slider>
     </div>
-    <button
-      mat-button
-      id="goToCanvasGroupButton"
-      class="canvasGroups"
-      (click)="openCanvasGroupDialog()"
-    >
+    <button mat-button class="canvasGroups" (click)="openCanvasGroupDialog()">
       <div fxLayout="row" fxLayoutGap="1px">
         <span id="currentCanvasGroupLabel">{{ canvasGroupLabel }}</span
         ><span>/</span

--- a/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer-footer/canvas-group-navigator/canvas-group-navigator.component.spec.ts
@@ -182,7 +182,7 @@ describe('CanvasGroupNavigatorComponent', () => {
 
       fixture.detectChanges();
       fixture.whenStable().then(() => {
-        const slider = fixture.debugElement.query(By.css('#navigationSlider'));
+        const slider = fixture.debugElement.query(By.css('.navigation-slider'));
         slider.nativeElement.dispatchEvent(event);
         fixture.detectChanges();
         expect(spy).toHaveBeenCalled();

--- a/libs/ngx-mime/src/lib/viewer/viewer-footer/content-search-navigator/content-search-navigator.component.html
+++ b/libs/ngx-mime/src/lib/viewer/viewer-footer/content-search-navigator/content-search-navigator.component.html
@@ -1,4 +1,4 @@
-<mat-toolbar id="content-search-navigator-toolbar" color="primary">
+<mat-toolbar class="content-search-navigator-toolbar" color="primary">
   <div
     *ngIf="searchResult"
     fxLayout="row"

--- a/libs/ngx-mime/src/lib/viewer/viewer-header/viewer-header.component.html
+++ b/libs/ngx-mime/src/lib/viewer/viewer-header/viewer-header.component.html
@@ -44,7 +44,7 @@
         </mime-icon>
       </button>
       <button
-        id="contentsDialogButton"
+        id="ngx-mimeContentsDialogButton"
         mat-icon-button
         [attr.aria-label]="intl.contentsLabel"
         [matTooltip]="intl.contentsLabel"
@@ -53,7 +53,7 @@
         <mat-icon aria-hidden="true">list</mat-icon>
       </button>
       <button
-        id="contentSearchDialogButton"
+        id="ngx-mimeContentSearchDialogButton"
         *ngIf="isContentSearchEnabled"
         mat-icon-button
         [attr.aria-label]="intl.searchLabel"
@@ -63,7 +63,7 @@
         <mat-icon aria-hidden="true">search</mat-icon>
       </button>
       <button
-        id="helpDialogButton"
+        id="ngx-mimeHelpDialogButton"
         mat-icon-button
         [attr.aria-label]="intl.help.helpLabel"
         [matTooltip]="intl.help.helpLabel"
@@ -73,7 +73,7 @@
       </button>
 
       <button
-        id="fullscreenButton"
+        id="ngx-mimeFullscreenButton"
         *ngIf="isFullscreenEnabled"
         mat-icon-button
         [attr.aria-label]="fullscreenLabel"

--- a/libs/ngx-mime/src/lib/viewer/viewer-header/viewer-header.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer-header/viewer-header.component.spec.ts
@@ -1,24 +1,24 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, inject, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ComponentFixture, TestBed, inject, waitForAsync } from '@angular/core/testing';
-
-import { ViewerHeaderTestModule } from './viewer-header-test.module';
 import { ContentSearchDialogModule } from '../../content-search-dialog/content-search-dialog.module';
-import { ViewerHeaderComponent } from './viewer-header.component';
+import { CanvasService } from '../../core/canvas-service/canvas-service';
+import { ClickService } from '../../core/click-service/click.service';
+import { IiifContentSearchService } from '../../core/iiif-content-search-service/iiif-content-search.service';
+import { ModeService } from '../../core/mode-service/mode.service';
+import { ViewerLayout } from '../../core/models/viewer-layout';
+import { ViewerLayoutService } from '../../core/viewer-layout-service/viewer-layout-service';
+import { ViewerService } from '../../core/viewer-service/viewer.service';
+import { HelpDialogModule } from '../../help-dialog/help-dialog.module';
+import { FullscreenService } from './../../core/fullscreen-service/fullscreen.service';
 import { IiifManifestService } from './../../core/iiif-manifest-service/iiif-manifest-service';
 import { MimeViewerIntl } from './../../core/intl/viewer-intl';
-import { FullscreenService } from './../../core/fullscreen-service/fullscreen.service';
-import { IiifManifestServiceStub } from './../../test/iiif-manifest-service-stub';
 import { MimeDomHelper } from './../../core/mime-dom-helper';
-import { ViewerLayoutService } from '../../core/viewer-layout-service/viewer-layout-service';
-import { ViewerLayout } from '../../core/models/viewer-layout';
-import { ViewerService } from '../../core/viewer-service/viewer.service';
-import { ClickService } from '../../core/click-service/click.service';
-import { ModeService } from '../../core/mode-service/mode.service';
-import { CanvasService } from '../../core/canvas-service/canvas-service';
-import { IiifContentSearchService } from '../../core/iiif-content-search-service/iiif-content-search.service';
 import { FullscreenServiceStub } from './../../test/fullscreen-service-stub';
-import { HelpDialogModule } from '../../help-dialog/help-dialog.module';
+import { IiifManifestServiceStub } from './../../test/iiif-manifest-service-stub';
+import { ViewerHeaderTestModule } from './viewer-header-test.module';
+import { ViewerHeaderComponent } from './viewer-header.component';
+
 
 describe('ViewerHeaderComponent', () => {
   let component: ViewerHeaderComponent;
@@ -57,7 +57,7 @@ describe('ViewerHeaderComponent', () => {
     [MimeViewerIntl],
     (intl: MimeViewerIntl) => {
       const button = fixture.debugElement.query(
-        By.css('#contentsDialogButton')
+        By.css('#ngx-mimeContentsDialogButton')
       );
 
       intl.contentsLabel = 'Metadata of the publication';
@@ -112,7 +112,7 @@ describe('ViewerHeaderComponent', () => {
 
       fixture.detectChanges();
 
-      const button = fixture.debugElement.query(By.css('#fullscreenButton'));
+      const button = fixture.debugElement.query(By.css('#ngx-mimeFullscreenButton'));
       expect(button).not.toBeNull();
     }
   ));
@@ -124,7 +124,7 @@ describe('ViewerHeaderComponent', () => {
 
       fixture.detectChanges();
 
-      const button = fixture.debugElement.query(By.css('#fullscreenButton'));
+      const button = fixture.debugElement.query(By.css('#ngx-mimeFullscreenButton'));
       expect(button).not.toBeNull();
     }
   ));
@@ -139,7 +139,7 @@ describe('ViewerHeaderComponent', () => {
       fixture.detectChanges();
 
       const button = fixture.debugElement.query(
-        By.css('#contentSearchDialogButton')
+        By.css('#ngx-mimeContentSearchDialogButton')
       );
       expect(button.nativeElement.getAttribute('aria-label')).toBe('Search');
     }
@@ -153,7 +153,7 @@ describe('ViewerHeaderComponent', () => {
       fixture.detectChanges();
 
       const button = fixture.debugElement.query(
-        By.css('#contentSearchDialogButton')
+        By.css('#ngx-mimeContentSearchDialogButton')
       );
       expect(button).toBeNull();
     }

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.html
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.html
@@ -1,5 +1,5 @@
 <div
-  id="mimeViewer"
+  id="ngx-mime-mimeViewer"
   class="viewer-container"
   [ngClass]="setClasses()"
   [hidden]="errorMessage !== null"

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.spec.ts
@@ -24,6 +24,7 @@ import { ViewerMode } from '../core/models/viewer-mode';
 import { ContentSearchNavigationService } from '../core/navigation/content-search-navigation-service/content-search-navigation.service';
 import { ViewerLayoutService } from '../core/viewer-layout-service/viewer-layout-service';
 import { ViewerService } from '../core/viewer-service/viewer.service';
+import { HelpDialogModule } from '../help-dialog/help-dialog.module';
 import { SharedModule } from '../shared/shared.module';
 import { MimeResizeServiceStub } from '../test/mime-resize-service-stub';
 import { ContentSearchDialogModule } from './../content-search-dialog/content-search-dialog.module';
@@ -35,9 +36,8 @@ import { TestHostComponent } from './test-host.component';
 import { ViewerFooterComponent } from './viewer-footer/viewer-footer.component';
 import { ViewerHeaderComponent } from './viewer-header/viewer-header.component';
 import { ViewerComponent } from './viewer.component';
-import { HelpDialogModule } from '../help-dialog/help-dialog.module';
 
-describe('ViewerComponent', function() {
+describe('ViewerComponent', function () {
   const matSnackBarSpy = jasmine.createSpy('MatSnackBar');
   const config: MimeViewerConfig = new MimeViewerConfig();
   const osdAnimationTime = 4000;
@@ -56,51 +56,53 @@ describe('ViewerComponent', function() {
   let iiifManifestServiceStub: IiifManifestServiceStub;
   let viewerLayoutService: ViewerLayoutService;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      imports: [
-        HttpClientTestingModule,
-        NoopAnimationsModule,
-        SharedModule,
-        ContentsDialogModule,
-        AttributionDialogModule,
-        ContentSearchDialogModule,
-        HelpDialogModule
-      ],
-      declarations: [
-        ViewerComponent,
-        TestHostComponent,
-        ViewerHeaderComponent,
-        ViewerFooterComponent,
-        TestDynamicComponent
-      ],
-      providers: [
-        { provide: MatSnackBar, useClass: matSnackBarSpy },
-        ViewerService,
-        { provide: IiifManifestService, useClass: IiifManifestServiceStub },
-        {
-          provide: IiifContentSearchService,
-          useClass: IiifContentSearchServiceStub
-        },
-        { provide: MimeResizeService, useClass: MimeResizeServiceStub },
-        MimeViewerIntl,
-        ClickService,
-        CanvasService,
-        ModeService,
-        FullscreenService,
-        AccessKeysService,
-        ViewerLayoutService,
-        ContentSearchNavigationService
-      ]
-    })
-      .overrideModule(BrowserDynamicTestingModule, {
-        set: {
-          entryComponents: [TestDynamicComponent]
-        }
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        imports: [
+          HttpClientTestingModule,
+          NoopAnimationsModule,
+          SharedModule,
+          ContentsDialogModule,
+          AttributionDialogModule,
+          ContentSearchDialogModule,
+          HelpDialogModule,
+        ],
+        declarations: [
+          ViewerComponent,
+          TestHostComponent,
+          ViewerHeaderComponent,
+          ViewerFooterComponent,
+          TestDynamicComponent,
+        ],
+        providers: [
+          { provide: MatSnackBar, useClass: matSnackBarSpy },
+          ViewerService,
+          { provide: IiifManifestService, useClass: IiifManifestServiceStub },
+          {
+            provide: IiifContentSearchService,
+            useClass: IiifContentSearchServiceStub,
+          },
+          { provide: MimeResizeService, useClass: MimeResizeServiceStub },
+          MimeViewerIntl,
+          ClickService,
+          CanvasService,
+          ModeService,
+          FullscreenService,
+          AccessKeysService,
+          ViewerLayoutService,
+          ContentSearchNavigationService,
+        ],
       })
-      .compileComponents();
-  }));
+        .overrideModule(BrowserDynamicTestingModule, {
+          set: {
+            entryComponents: [TestDynamicComponent],
+          },
+        })
+        .compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ViewerComponent);
@@ -127,7 +129,7 @@ describe('ViewerComponent', function() {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
   });
 
-  afterEach(function() {
+  afterEach(function () {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
   });
 
@@ -149,7 +151,9 @@ describe('ViewerComponent', function() {
     testHostComponent.tabIndex = 1;
     testHostFixture.detectChanges();
 
-    const viewerDe = testHostFixture.debugElement.query(By.css('#mimeViewer'));
+    const viewerDe = testHostFixture.debugElement.query(
+      By.css('.viewer-container')
+    );
     expect(viewerDe.nativeElement.getAttribute('tabindex')).toBe('1');
   });
 
@@ -157,7 +161,7 @@ describe('ViewerComponent', function() {
     expect(modeService.mode).toBe(config.initViewerMode);
   });
 
-  it('should change mode to initial-mode when changing manifest', done => {
+  it('should change mode to initial-mode when changing manifest', (done) => {
     viewerService.onOsdReadyChange.subscribe((state: boolean) => {
       if (state) {
         setTimeout(() => {
@@ -392,7 +396,7 @@ describe('ViewerComponent', function() {
     expect(selectedMode).toEqual(ViewerMode.DASHBOARD);
   });
 
-  it('should emit when canvas group number changes', done => {
+  it('should emit when canvas group number changes', (done) => {
     let currentCanvasIndex: number;
     comp.canvasChanged.subscribe(
       (canvasIndex: number) => (currentCanvasIndex = canvasIndex)
@@ -442,12 +446,12 @@ describe('ViewerComponent', function() {
 
     iiifManifestServiceStub._currentManifest.next(
       new Manifest({
-        id: 'dummyid'
+        id: 'dummyid',
       })
     );
   });
 
-  it('should open viewer on canvas index if present', done => {
+  it('should open viewer on canvas index if present', (done) => {
     let currentCanvasIndex: number;
     testHostComponent.canvasIndex = 12;
     comp.canvasChanged.subscribe((canvasIndex: number) => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Theme files contain css rules for #metadata-container and #toc-container selectors and various other generic ids are used in the DOM.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
#metadata-container and #toc-container are not used in theme files, and ngx-mime no longer uses id's for various internal components.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Apps relying on style from the theme to style their own components must use the new classes .ngx-mime-metadata-container and .ngx-mime-toc-container instead. Apps using internal ids to style or access internal components must be re-written accordingly.

## Other information
