### PR TITLE
Fix: free all OpenSeadragon resources on destroy

### DIFF
--- a/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.spec.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.spec.ts
@@ -17,9 +17,7 @@ import { ModeService } from './../mode-service/mode.service';
 import { ViewerService } from './viewer.service';
 
 @Component({
-  template: `
-    <div id="openseadragon"></div>
-  `
+  template: ` <div id="openseadragon"></div> `,
 })
 class TestHostComponent {}
 
@@ -41,8 +39,8 @@ describe('ViewerService', () => {
         IiifContentSearchService,
         HttpClient,
         HttpHandler,
-        MediaObserver
-      ]
+        MediaObserver,
+      ],
     });
 
     viewerLayoutService = TestBed.inject(ViewerLayoutService);
@@ -63,7 +61,7 @@ describe('ViewerService', () => {
     (viewerService: ViewerService) => {
       viewerService.currentSearch = new SearchResult({
         q: 'Donald Duck',
-        hits: new Array<Hit>()
+        hits: new Array<Hit>(),
       });
       viewerService.destroy(true);
       expect(viewerService.currentSearch).not.toBeNull();
@@ -76,14 +74,14 @@ describe('ViewerService', () => {
     (viewerService: ViewerService) => {
       viewerService.currentSearch = new SearchResult({
         q: 'Donald Duck',
-        hits: new Array<Hit>()
+        hits: new Array<Hit>(),
       });
       viewerService.destroy();
       expect(viewerService.currentSearch).toBeNull();
     }
   ));
 
-  it('should keep state of rotation on destroy when layoutSwitch = true', function(done) {
+  it('should keep state of rotation on destroy when layoutSwitch = true', function (done) {
     inject([ViewerService], (viewerService: ViewerService) => {
       let rotation: number;
       viewerService.onRotationChange.subscribe((serviceRotation: number) => {
@@ -94,7 +92,7 @@ describe('ViewerService', () => {
         new MimeViewerConfig()
       );
 
-      viewerService.onOsdReadyChange.subscribe(state => {
+      viewerService.onOsdReadyChange.subscribe((state) => {
         if (state) {
           viewerService.rotate();
           viewerService.destroy(true);
@@ -105,7 +103,7 @@ describe('ViewerService', () => {
     })();
   });
 
-  it('should set rotation to 0 on destroy', function(done) {
+  it('should set rotation to 0 on destroy', function (done) {
     inject([ViewerService], (viewerService: ViewerService) => {
       let rotation: number;
       viewerService.onRotationChange.subscribe((serviceRotation: number) => {
@@ -116,11 +114,28 @@ describe('ViewerService', () => {
         new MimeViewerConfig()
       );
 
-      viewerService.onOsdReadyChange.subscribe(state => {
+      viewerService.onOsdReadyChange.subscribe((state) => {
         if (state) {
           viewerService.rotate();
           viewerService.destroy();
           expect(rotation).toEqual(0);
+          done();
+        }
+      });
+    })();
+  });
+
+  it('should set viewer to null on destroy', function (done) {
+    inject([ViewerService], (viewerService: ViewerService) => {
+      viewerService.setUpViewer(
+        new ManifestBuilder(testManifest).build(),
+        new MimeViewerConfig()
+      );
+
+      viewerService.onOsdReadyChange.subscribe((state) => {
+        if (state) {
+          viewerService.destroy();
+          expect(viewerService.getViewer()).toBeNull();
           done();
         }
       });

--- a/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.ts
@@ -39,7 +39,7 @@ import { DefaultZoomStrategy, ZoomStrategy } from './zoom-strategy';
 declare const OpenSeadragon: any;
 @Injectable()
 export class ViewerService {
-  private viewer: any;
+  private viewer?: any;
   private svgOverlay: any;
   private svgNode: any;
   private config: MimeViewerConfig;
@@ -325,7 +325,7 @@ export class ViewerService {
       .subscribe((state: boolean) => {
         if (state) {
           this.initialCanvasGroupLoaded();
-          this.currentCenter.next(this.viewer.viewport.getCenter(true));
+          this.currentCenter.next(this.viewer?.viewport.getCenter(true));
         }
       });
 
@@ -400,6 +400,7 @@ export class ViewerService {
         d3.select(this.viewer.container.parentNode).style('opacity', '0');
       }
       this.viewer.destroy();
+      this.viewer = null;
     }
     this.destroyed.next();
     this.overlays = null;
@@ -420,7 +421,7 @@ export class ViewerService {
     this.clickService.addSingleClickHandler(this.singleClickHandler);
     this.clickService.addDoubleClickHandler(this.dblClickHandler);
     this.viewer.addHandler('animation-finish', () => {
-      this.currentCenter.next(this.viewer.viewport.getCenter(true));
+      this.currentCenter.next(this.viewer?.viewport.getCenter(true));
     });
     this.viewer.addHandler('canvas-click', this.clickService.click);
     this.viewer.addHandler(
@@ -444,7 +445,7 @@ export class ViewerService {
     );
 
     this.viewer.addHandler('animation', (e: any) => {
-      this.currentCenter.next(this.viewer.viewport.getCenter(true));
+      this.currentCenter.next(this.viewer?.viewport.getCenter(true));
     });
   }
 
@@ -629,7 +630,7 @@ export class ViewerService {
     if (requestedCanvasGroupIndex) {
       this.canvasService.currentCanvasGroupIndex = requestedCanvasGroupIndex;
     } else {
-      this.calculateCurrentCanvasGroup(this.viewer.viewport.getCenter(true));
+      this.calculateCurrentCanvasGroup(this.viewer?.viewport.getCenter(true));
     }
     this.modeService.toggleMode();
   };
@@ -659,7 +660,7 @@ export class ViewerService {
       if (requestedCanvasGroupIndex >= 0) {
         this.canvasService.currentCanvasGroupIndex = requestedCanvasGroupIndex;
       } else {
-        this.calculateCurrentCanvasGroup(this.viewer.viewport.getCenter(true));
+        this.calculateCurrentCanvasGroup(this.viewer?.viewport.getCenter(true));
       }
     }
   };
@@ -910,6 +911,6 @@ export class ViewerService {
   }
 
   private getViewportBounds(): Rect {
-    return this.viewer.viewport.getBounds();
+    return this.viewer?.viewport.getBounds();
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Not all OpenSeadragon resources are freed when calling ViewerService.destroy()

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
 All OpenSeadragon resources are freed when calling ViewerService.destroy()

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
