### PR TITLE
build: remove xml2js build warnings

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -46,7 +46,6 @@
         "build": {
           "builder": "@nrwl/angular:package",
           "options": {
-            "allowedCommonJsDependencies": ["xml2js"],
             "tsConfig": "libs/ngx-mime/tsconfig.lib.json",
             "project": "libs/ngx-mime/ng-package.json",
             "buildableProjectDepsInPackageJsonType": "dependencies"
@@ -94,7 +93,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "allowedCommonJsDependencies": ["openseadragon"],
+            "allowedCommonJsDependencies": ["openseadragon", "xml2js"],
             "aot": true,
             "outputPath": "dist/apps/demo",
             "index": "apps/demo/src/index.html",
@@ -212,6 +211,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
+            "allowedCommonJsDependencies": ["openseadragon", "xml2js"],
             "aot": true,
             "outputPath": "dist/apps/integration",
             "index": "apps/integration/src/index.html",
@@ -349,7 +349,7 @@
         "build": {
           "builder": "ngx-build-plus:browser",
           "options": {
-            "allowedCommonJsDependencies": ["openseadragon"],
+            "allowedCommonJsDependencies": ["openseadragon", "xml2js"],
             "outputPath": "dist/apps/elements",
             "index": "apps/elements/src/index.html",
             "main": "apps/elements/src/main.ts",

--- a/libs/ngx-mime/ng-package.prod.json
+++ b/libs/ngx-mime/ng-package.prod.json
@@ -6,7 +6,8 @@
     "entryFile": "src/index.ts",
     "umdModuleIds": {
       "d3": "d3",
-      "openseadragon": "OpenSeadragon"
+      "openseadragon": "OpenSeadragon",
+      "xml2js": "xml2js"
     }
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
building library gives warning:
```WARNING: No name was provided for external module 'xml2js' in output.globals – guessing 'xml2js'```
and
```alto.service.ts depends on 'xml2js'. CommonJS or AMD dependencies can cause optimization bailouts```
Issue Number: N/A

## What is the new behavior?

ng-packagr no longer needs to guess and xml2js added to allowedCommonJsDependencies

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
