### PR TITLE
fix: recognized text content is not opened

### DIFF
--- a/libs/ngx-mime/src/lib/viewer/viewer.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.ts
@@ -287,6 +287,7 @@ export class ViewerComponent
           this.recognizedTextContentToggleChanged.emit(
             isRecognizedTextContentToggled
           );
+          this.changeDetectorRef.markForCheck();
         }
       )
     );


### PR DESCRIPTION
Fixes #349

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #349 

## What is the new behavior?
Recognized text content is opened when clicking the access key 't' when the attribution dialog is open. It was missing  markForCheck when using access key 't'

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
