### PR TITLE
fix: Traversing nested ComposeBlocks to get all TextBlocks

### DIFF
--- a/libs/ngx-mime/src/lib/core/alto-service/alto.service.ts
+++ b/libs/ngx-mime/src/lib/core/alto-service/alto.service.ts
@@ -163,7 +163,7 @@ export class AltoService {
       .subscribe((data: Alto | any) => {
         try {
           if (!data.isError) {
-            parseString(data, {}, (error, result) => {
+            parseString(data, { explicitChildren: true, preserveChildrenOrder: true}, (error, result) => {
               const alto = this.altoBuilder.withAltoXml(result.alto).build();
               this.addToCache(index, alto);
               this.done(observer);

--- a/libs/ngx-mime/src/lib/core/builders/alto/alto.builder.spec.ts
+++ b/libs/ngx-mime/src/lib/core/builders/alto/alto.builder.spec.ts
@@ -4,7 +4,7 @@ import { AltoBuilder } from '../../builders/alto';
 
 describe('AltoBuilder', () => {
   it('should build altoxml', () => {
-    parseString(testAlto, {}, (error, result) => {
+    parseString(testAlto, { preserveChildrenOrder: true, explicitChildren: true}, (error, result) => {
       const alto = new AltoBuilder().withAltoXml(result.alto).build();
 
       const textBlocks = alto.layout.page.printSpace.textBlocks;

--- a/libs/ngx-mime/src/lib/core/builders/alto/print-space.builder.ts
+++ b/libs/ngx-mime/src/lib/core/builders/alto/print-space.builder.ts
@@ -20,16 +20,8 @@ export class PrintSpaceBuilder {
   build(): PrintSpace {
     let textBlocks: any[] = [];
 
-    if (this.printSpaceXml.TextBlock) {
-      textBlocks = [...textBlocks, ...this.printSpaceXml.TextBlock];
-    }
-    if (this.printSpaceXml.ComposedBlock) {
-      textBlocks = [
-        ...textBlocks,
-        ...this.printSpaceXml.ComposedBlock.filter(
-          (t: any) => t.TextBlock !== undefined
-        ).flatMap((t: any) => t.TextBlock),
-      ];
+    if (this.printSpaceXml.$$) {
+      textBlocks = this.extractTextBlocks(this.printSpaceXml.$$);
     }
     return {
       textBlocks: new TextBlocksBuilder()
@@ -37,5 +29,27 @@ export class PrintSpaceBuilder {
         .withTextStyles(this.textStyles)
         .build(),
     };
+  }
+
+  private extractTextBlocks(node: any): any[] {
+    let blocks: any[] = [];
+    node.forEach((n: any) => {
+      if (this.isTextBlock(n)) {
+        blocks = [...blocks, n];
+      } else if (this.isComposedBlock(n)) {
+        if (n.$$) {
+          blocks = [...blocks, ...this.extractTextBlocks(n.$$)];
+        }
+      }
+    });
+    return blocks;
+  }
+
+  private isTextBlock(n: any): boolean {
+    return n['#name'] && n['#name'] === 'TextBlock';
+  }
+
+  private isComposedBlock(n: any): boolean {
+    return n['#name'] && n['#name'] === 'ComposedBlock';
   }
 }

--- a/libs/ngx-mime/src/lib/test/testAltos.ts
+++ b/libs/ngx-mime/src/lib/test/testAltos.ts
@@ -50,17 +50,19 @@ export let testAlto = `<?xml version="1.0" encoding="UTF-8"?>
 						<String ID="P31_ST00004" HPOS="617" VPOS="1337" WIDTH="238" HEIGHT="38" CONTENT="skadetrygd" WC="0.71" CC="4005006056"/>
 					</TextLine>
 				</TextBlock>
-				<ComposedBlock ID="P31_CB00001" HPOS="164" VPOS="730" WIDTH="745" HEIGHT="270" TYPE="Formula">
-					<TextBlock ID="P31_TB00002" HPOS="164" VPOS="730" WIDTH="745" HEIGHT="270" STYLEREFS="TXT_1 PAR_LEFT">
-						<TextLine ID="P31_TL00002" HPOS="164" VPOS="850" WIDTH="745" HEIGHT="97">
-							<String ID="P31_ST00005" HPOS="164" VPOS="850" WIDTH="745" HEIGHT="97" CONTENT="Itorøts^Jnmnftassr" WC="0.23" CC="777778788887667788"/>
-						</TextLine>
-						<TextLine ID="P31_TL00003" HPOS="441" VPOS="973" WIDTH="196" HEIGHT="27">
-							<String ID="P31_ST00006" HPOS="441" VPOS="973" WIDTH="128" HEIGHT="27" CONTENT="Grunnlagt" WC="1.00" CC="030520000" STYLEREFS="TXT_2"/>
-							<SP ID="P31_SP00004" HPOS="569" VPOS="1000" WIDTH="14"/>
-							<String ID="P31_ST00007" HPOS="583" VPOS="973" WIDTH="54" HEIGHT="23" CONTENT="1767" WC="0.97" CC="0000" STYLEREFS="TXT_2"/>
-						</TextLine>
-					</TextBlock>
+				<ComposedBlock>
+          <ComposedBlock ID="P31_CB00001" HPOS="164" VPOS="730" WIDTH="745" HEIGHT="270" TYPE="Formula">
+            <TextBlock ID="P31_TB00002" HPOS="164" VPOS="730" WIDTH="745" HEIGHT="270" STYLEREFS="TXT_1 PAR_LEFT">
+              <TextLine ID="P31_TL00002" HPOS="164" VPOS="850" WIDTH="745" HEIGHT="97">
+                <String ID="P31_ST00005" HPOS="164" VPOS="850" WIDTH="745" HEIGHT="97" CONTENT="Itorøts^Jnmnftassr" WC="0.23" CC="777778788887667788"/>
+              </TextLine>
+              <TextLine ID="P31_TL00003" HPOS="441" VPOS="973" WIDTH="196" HEIGHT="27">
+                <String ID="P31_ST00006" HPOS="441" VPOS="973" WIDTH="128" HEIGHT="27" CONTENT="Grunnlagt" WC="1.00" CC="030520000" STYLEREFS="TXT_2"/>
+                <SP ID="P31_SP00004" HPOS="569" VPOS="1000" WIDTH="14"/>
+                <String ID="P31_ST00007" HPOS="583" VPOS="973" WIDTH="54" HEIGHT="23" CONTENT="1767" WC="0.97" CC="0000" STYLEREFS="TXT_2"/>
+              </TextLine>
+            </TextBlock>
+          </ComposedBlock>
 				</ComposedBlock>
 				<ComposedBlock ID="P31_CB00002" HPOS="189" VPOS="1033" WIDTH="699" HEIGHT="27" TYPE="Formula">
 					<TextBlock ID="P31_TB00003" HPOS="189" VPOS="1033" WIDTH="699" HEIGHT="27" STYLEREFS="TXT_2 PAR_LEFT">


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/NationalLibraryOfNorway/ngx-mime/issues/351

## What is the new behavior?
Recognized text will now be shown for alto files containing nested ComposedBlocks

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

## Other information
