### PR TITLE
fix: double scrollbar for recognized-text

### DIFF
--- a/libs/ngx-mime/src/lib/viewer/recognized-text-content/recognized-text-content.component.scss
+++ b/libs/ngx-mime/src/lib/viewer/recognized-text-content/recognized-text-content.component.scss
@@ -1,5 +1,8 @@
 .recognized-text-content-container {
-  padding: 1em 1em;
   height: 100%;
   overflow: auto;
+
+  & > div {
+    padding: 1em 1em;
+  }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Opening recognized text with large amount of text makes the container grow outside the viewport and generates double scrollbar

Issue Number: https://github.com/NationalLibraryOfNorway/ngx-mime/issues/355

## What is the new behavior?

Recognized text container does not stretch outside viewport

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
