### PR TITLE
fix: re-initialize subscriptions before adding

### DIFF
--- a/libs/ngx-mime/src/lib/core/viewer-service/canvas-group-mask.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/canvas-group-mask.ts
@@ -24,6 +24,7 @@ export class CanvasGroupMask {
   }
 
   public initialize(pageBounds: Rect, visible: boolean): void {
+    this.unsubscribe();
     this.subscriptions = new Subscription();
 
     this.subscriptions.add(

--- a/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.ts
@@ -110,6 +110,7 @@ export class ViewerService {
   }
 
   initialize() {
+    this.unsubscribe();
     this.subscriptions = new Subscription();
   }
 
@@ -302,6 +303,7 @@ export class ViewerService {
   }
 
   addSubscriptions(): void {
+    this.initialize();
     this.subscriptions.add(
       this.modeService.onChange.subscribe((mode: ModeChanges) => {
         this.modeChanged(mode);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Each time the user rotates the object all subscriptions in ViewerService and CanvasGroupMask are re-added, which leads to new page masks being added for each rotation.

Issue Number: N/A

## What is the new behavior?

The subscription handling in ViewerService and  CanvasGroupMask now unsubscribes before adding.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
