### PR TITLE
fix: recognized text drawer hiding parts of image

### DIFF
--- a/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.ts
@@ -635,6 +635,10 @@ export class ViewerService {
     }
   }
 
+  goToHomeZoom(): void {
+    this.zoomStrategy.goToHomeZoom();
+  }
+
   /**
    * Single-click-handler
    * Single-click toggles between page/dashboard-mode if a page is hit

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.html
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.html
@@ -19,6 +19,7 @@
     <mat-drawer
       mode="side"
       position="end"
+      (openedChange)="goToHomeZoom()"
       [opened]="isRecognizedTextContentToggled"
       [ngClass]="{'open': showHeaderAndFooterState === 'show'}"
       ><mime-recognized-text-content

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.ts
@@ -466,6 +466,10 @@ export class ViewerComponent
     this.errorMessage = null;
   }
 
+  goToHomeZoom(): void {
+    this.viewerService.goToHomeZoom();
+  }
+
   setClasses() {
     return {
       'mode-page': this.modeService.mode === ViewerMode.PAGE,


### PR DESCRIPTION
…drawer overlaying images

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/NationalLibraryOfNorway/ngx-mime/issues/359

## What is the new behavior?
When the drawer for recognized text is fully opened/closed it will go to home zoom

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
