### PR TITLE
feat: ignorePhysicalScale toggle in MimeViewerConfig

### DIFF
--- a/libs/ngx-mime/src/lib/core/builders/search-result.builder.spec.ts
+++ b/libs/ngx-mime/src/lib/core/builders/search-result.builder.spec.ts
@@ -7,11 +7,16 @@ import { ManifestBuilder } from './manifest.builder';
 import { SearchResultBuilder } from './search-result.builder';
 
 describe('SearchResultBuilder', () => {
+  let config: MimeViewerConfig;
+
+  beforeEach(() => {
+    config = new MimeViewerConfig();
+  });
+
   it('should build empty search result', () => {
     const q = 'testquery';
     const manifest = new Manifest({});
     const iiifSearchResult: IiifSearchResult = {};
-    const config = new MimeViewerConfig();
     const searchResult = new SearchResultBuilder(
       q,
       manifest,
@@ -24,7 +29,6 @@ describe('SearchResultBuilder', () => {
   it('should return search result for 400 dpi manifest', () => {
     const q = 'america';
     const manifest = new ManifestBuilder(a400dpiManifest).build();
-    const config = new MimeViewerConfig();
     const searchResult = new SearchResultBuilder(
       q,
       manifest,
@@ -46,7 +50,6 @@ describe('SearchResultBuilder', () => {
   it('should return search result for 300 dpi manifest', () => {
     const q = 'america';
     const manifest = new ManifestBuilder(a300dpiManifest).build();
-    const config = new MimeViewerConfig();
     const searchResult = new SearchResultBuilder(
       q,
       manifest,

--- a/libs/ngx-mime/src/lib/core/builders/search-result.builder.spec.ts
+++ b/libs/ngx-mime/src/lib/core/builders/search-result.builder.spec.ts
@@ -1,19 +1,22 @@
-import { ManifestBuilder } from './manifest.builder';
-import { IiifSearchResult } from './../models/iiif-search-result';
-import { Manifest } from './../models/manifest';
-import { SearchResultBuilder } from './search-result.builder';
 import { a300dpiManifest, a400dpiManifest } from '../../test/testManifest';
 import { testSearchResult } from '../../test/testSearchResult';
+import { MimeViewerConfig } from '../mime-viewer-config';
+import { IiifSearchResult } from './../models/iiif-search-result';
+import { Manifest } from './../models/manifest';
+import { ManifestBuilder } from './manifest.builder';
+import { SearchResultBuilder } from './search-result.builder';
 
 describe('SearchResultBuilder', () => {
   it('should build empty search result', () => {
     const q = 'testquery';
     const manifest = new Manifest({});
     const iiifSearchResult: IiifSearchResult = {};
+    const config = new MimeViewerConfig();
     const searchResult = new SearchResultBuilder(
       q,
       manifest,
-      iiifSearchResult
+      iiifSearchResult,
+      config
     ).build();
     expect(searchResult).not.toBeNull();
   });
@@ -21,10 +24,12 @@ describe('SearchResultBuilder', () => {
   it('should return search result for 400 dpi manifest', () => {
     const q = 'america';
     const manifest = new ManifestBuilder(a400dpiManifest).build();
+    const config = new MimeViewerConfig();
     const searchResult = new SearchResultBuilder(
       q,
       manifest,
-      testSearchResult
+      testSearchResult,
+      config
     ).build();
 
     expect(searchResult.hits.length).toEqual(2);
@@ -41,10 +46,12 @@ describe('SearchResultBuilder', () => {
   it('should return search result for 300 dpi manifest', () => {
     const q = 'america';
     const manifest = new ManifestBuilder(a300dpiManifest).build();
+    const config = new MimeViewerConfig();
     const searchResult = new SearchResultBuilder(
       q,
       manifest,
-      testSearchResult
+      testSearchResult,
+      config
     ).build();
 
     expect(searchResult.hits.length).toEqual(2);

--- a/libs/ngx-mime/src/lib/core/builders/search-result.builder.ts
+++ b/libs/ngx-mime/src/lib/core/builders/search-result.builder.ts
@@ -1,3 +1,4 @@
+import { MimeViewerConfig } from '../mime-viewer-config';
 import { Utils } from '../utils';
 import { Hit } from './../models/hit';
 import {
@@ -13,7 +14,8 @@ export class SearchResultBuilder {
   constructor(
     private q: string,
     private manifest: Manifest,
-    private iiifSearchResult: IiifSearchResult
+    private iiifSearchResult: IiifSearchResult,
+    private config: MimeViewerConfig
   ) {}
 
   public build(): SearchResult {
@@ -114,7 +116,7 @@ export class SearchResultBuilder {
 
   private getScale(index: number): number {
     const physicalScale = this.getPhysicalScale(index);
-    return Utils.getScaleFactor(physicalScale);
+    return Utils.getScaleFactor(physicalScale, this.config.ignorePhysicalScale);
   }
 
   private getPhysicalScale(index: number): number | undefined {
@@ -123,6 +125,6 @@ export class SearchResultBuilder {
   }
 
   private scaleValue(value: string, scale: number): number {
-    return Math.trunc(parseInt(value, 10) * scale)
+    return Math.trunc(parseInt(value, 10) * scale);
   }
 }

--- a/libs/ngx-mime/src/lib/core/canvas-group-position/calculate-canvas-group-position-factory.ts
+++ b/libs/ngx-mime/src/lib/core/canvas-group-position/calculate-canvas-group-position-factory.ts
@@ -2,16 +2,18 @@ import { CalculateCanvasGroupPositionStrategy } from './calculate-canvas-group-p
 import { OnePageCalculatePagePositionStrategy } from './one-page-calculate-page-position-strategy';
 import { TwoPageCalculateCanvasGroupPositionStrategy } from './two-page-calculate-page-position-strategy';
 import { ViewerLayout } from '../models/viewer-layout';
+import { MimeViewerConfig } from '../mime-viewer-config';
 
 export class CalculateCanvasGroupPositionFactory {
   public static create(
     viewerLayout: ViewerLayout,
-    paged: boolean
+    paged: boolean,
+    config: MimeViewerConfig
   ): CalculateCanvasGroupPositionStrategy {
     if (viewerLayout === ViewerLayout.ONE_PAGE || !paged) {
-      return new OnePageCalculatePagePositionStrategy();
+      return new OnePageCalculatePagePositionStrategy(config);
     } else {
-      return new TwoPageCalculateCanvasGroupPositionStrategy();
+      return new TwoPageCalculateCanvasGroupPositionStrategy(config);
     }
   }
 }

--- a/libs/ngx-mime/src/lib/core/canvas-group-position/calculate-canvas-group-position-strategy.ts
+++ b/libs/ngx-mime/src/lib/core/canvas-group-position/calculate-canvas-group-position-strategy.ts
@@ -1,4 +1,5 @@
-import { Resource, Service } from '../models/manifest';
+import { MimeViewerConfig } from '../mime-viewer-config';
+import { Resource } from '../models/manifest';
 import { Rect } from '../models/rect';
 import { ViewingDirection } from '../models/viewing-direction';
 

--- a/libs/ngx-mime/src/lib/core/canvas-group-position/calculate-canvas-group-position-strategy.ts
+++ b/libs/ngx-mime/src/lib/core/canvas-group-position/calculate-canvas-group-position-strategy.ts
@@ -1,4 +1,3 @@
-import { MimeViewerConfig } from '../mime-viewer-config';
 import { Resource } from '../models/manifest';
 import { Rect } from '../models/rect';
 import { ViewingDirection } from '../models/viewing-direction';

--- a/libs/ngx-mime/src/lib/core/canvas-group-position/calculate-canvas-group-position-utils.spec.ts
+++ b/libs/ngx-mime/src/lib/core/canvas-group-position/calculate-canvas-group-position-utils.spec.ts
@@ -21,63 +21,134 @@ describe('canvasRectFromCriteria', () => {
     viewingDirection: ViewingDirection.LTR,
     previousCanvasGroupPosition: new Rect(),
   };
+  describe('using physicalScale', () => {
+    it('should return Rect', () => {
+      const canvasRect = canvasRectFromCriteria(
+        0,
+        canvasGroupsPositionCriteria,
+        10,
+        false
+      );
 
-  it('should return Rect', () => {
-    const canvasRect = canvasRectFromCriteria(
-      0,
-      canvasGroupsPositionCriteria,
-      10
-    );
+      expect(canvasRect).toEqual(
+        new Rect({ x: 10, y: -100, width: 100, height: 200 })
+      );
+    });
 
-    expect(canvasRect).toEqual(
-      new Rect({ x: 10, y: -100, width: 100, height: 200 })
-    );
+    it('should rotate 90 degrees', () => {
+      const canvasRect = canvasRectFromCriteria(
+        90,
+        canvasGroupsPositionCriteria,
+        10,
+        false
+      );
+
+      expect(canvasRect).toEqual(
+        new Rect({ x: 10, y: -50, width: 200, height: 100 })
+      );
+    });
+
+    it('should rotate 180 degrees', () => {
+      const canvasRect = canvasRectFromCriteria(
+        180,
+        canvasGroupsPositionCriteria,
+        10,
+        false
+      );
+
+      expect(canvasRect).toEqual(
+        new Rect({ x: 10, y: -100, width: 100, height: 200 })
+      );
+    });
+
+    it('should rotate 270 degrees', () => {
+      const canvasRect = canvasRectFromCriteria(
+        270,
+        canvasGroupsPositionCriteria,
+        10,
+        false
+      );
+
+      expect(canvasRect).toEqual(
+        new Rect({ x: 10, y: -50, width: 200, height: 100 })
+      );
+    });
+    it('should rotate 360 degrees', () => {
+      const canvasRect = canvasRectFromCriteria(
+        360,
+        canvasGroupsPositionCriteria,
+        10,
+        false
+      );
+
+      expect(canvasRect).toEqual(
+        new Rect({ x: 10, y: -100, width: 100, height: 200 })
+      );
+    });
   });
+  describe('ignoring physicalScale', () => {
+    it('should return Rect', () => {
+      const canvasRect = canvasRectFromCriteria(
+        0,
+        canvasGroupsPositionCriteria,
+        10,
+        true
+      );
 
-  it('should rotate 90 degrees', () => {
-    const canvasRect = canvasRectFromCriteria(
-      90,
-      canvasGroupsPositionCriteria,
-      10
-    );
+      expect(canvasRect).toEqual(
+        new Rect({ x: 10, y: -100, width: 100, height: 200 })
+      );
+    });
 
-    expect(canvasRect).toEqual(
-      new Rect({ x: 10, y: -50, width: 200, height: 100 })
-    );
-  });
+    it('should rotate 90 degrees', () => {
+      const canvasRect = canvasRectFromCriteria(
+        90,
+        canvasGroupsPositionCriteria,
+        10,
+        true
+      );
 
-  it('should rotate 180 degrees', () => {
-    const canvasRect = canvasRectFromCriteria(
-      180,
-      canvasGroupsPositionCriteria,
-      10
-    );
+      expect(canvasRect).toEqual(
+        new Rect({ x: 10, y: -50, width: 200, height: 100 })
+      );
+    });
 
-    expect(canvasRect).toEqual(
-      new Rect({ x: 10, y: -100, width: 100, height: 200 })
-    );
-  });
+    it('should rotate 180 degrees', () => {
+      const canvasRect = canvasRectFromCriteria(
+        180,
+        canvasGroupsPositionCriteria,
+        10,
+        true
+      );
 
-  it('should rotate 270 degrees', () => {
-    const canvasRect = canvasRectFromCriteria(
-      270,
-      canvasGroupsPositionCriteria,
-      10
-    );
+      expect(canvasRect).toEqual(
+        new Rect({ x: 10, y: -100, width: 100, height: 200 })
+      );
+    });
 
-    expect(canvasRect).toEqual(
-      new Rect({ x: 10, y: -50, width: 200, height: 100 })
-    );
-  });
-  it('should rotate 360 degrees', () => {
-    const canvasRect = canvasRectFromCriteria(
-      360,
-      canvasGroupsPositionCriteria,
-      10
-    );
+    it('should rotate 270 degrees', () => {
+      const canvasRect = canvasRectFromCriteria(
+        270,
+        canvasGroupsPositionCriteria,
+        10,
+        true
+      );
 
-    expect(canvasRect).toEqual(
-      new Rect({ x: 10, y: -100, width: 100, height: 200 })
-    );
+      expect(canvasRect).toEqual(
+        new Rect({ x: 10, y: -50, width: 200, height: 100 })
+      );
+    });
+    it('should rotate 360 degrees', () => {
+      const canvasRect = canvasRectFromCriteria(
+        360,
+        canvasGroupsPositionCriteria,
+        10,
+        true
+      );
+
+      expect(canvasRect).toEqual(
+        new Rect({ x: 10, y: -100, width: 100, height: 200 })
+      );
+    });
   });
 });

--- a/libs/ngx-mime/src/lib/core/canvas-group-position/calculate-canvas-group-position-utils.ts
+++ b/libs/ngx-mime/src/lib/core/canvas-group-position/calculate-canvas-group-position-utils.ts
@@ -1,17 +1,18 @@
-import { Utils } from '../utils';
 import { Rect } from '../models/rect';
+import { Utils } from '../utils';
 import { CanvasGroupPositionCriteria } from './calculate-canvas-group-position-strategy';
 
 export const canvasRectFromCriteria = (
   rotation: number,
   criteria: CanvasGroupPositionCriteria,
-  x: number
+  x: number,
+  ignorePhysicalScale: boolean
 ) => {
   let rect = {};
   const scale = Utils.getScaleFactor(
-    criteria.canvasSource.service?.service?.physicalScale
+    criteria.canvasSource.service?.service?.physicalScale,
+    ignorePhysicalScale
   );
-
   if (rotation === 90 || rotation === 270) {
     rect = {
       height: Math.trunc(criteria.canvasSource.width * scale),

--- a/libs/ngx-mime/src/lib/core/canvas-group-position/one-page-calculate-page-position-strategy.ts
+++ b/libs/ngx-mime/src/lib/core/canvas-group-position/one-page-calculate-page-position-strategy.ts
@@ -11,6 +11,7 @@ import { canvasRectFromCriteria } from './calculate-canvas-group-position-utils'
 export class OnePageCalculatePagePositionStrategy
   implements CalculateCanvasGroupPositionStrategy {
   constructor(private config: MimeViewerConfig) {}
+
   calculateCanvasGroupPosition(
     criteria: CanvasGroupPositionCriteria,
     rotation: number = 0

--- a/libs/ngx-mime/src/lib/core/canvas-group-position/one-page-calculate-page-position-strategy.ts
+++ b/libs/ngx-mime/src/lib/core/canvas-group-position/one-page-calculate-page-position-strategy.ts
@@ -1,14 +1,16 @@
+import { MimeViewerConfig } from '../mime-viewer-config';
 import { Rect } from '../models/rect';
 import { ViewerOptions } from '../models/viewer-options';
 import { ViewingDirection } from '../models/viewing-direction';
 import {
   CalculateCanvasGroupPositionStrategy,
-  CanvasGroupPositionCriteria
+  CanvasGroupPositionCriteria,
 } from './calculate-canvas-group-position-strategy';
 import { canvasRectFromCriteria } from './calculate-canvas-group-position-utils';
 
 export class OnePageCalculatePagePositionStrategy
   implements CalculateCanvasGroupPositionStrategy {
+  constructor(private config: MimeViewerConfig) {}
   calculateCanvasGroupPosition(
     criteria: CanvasGroupPositionCriteria,
     rotation: number = 0
@@ -26,7 +28,12 @@ export class OnePageCalculatePagePositionStrategy
           ? this.calculateLtrX(criteria)
           : this.calculateRtlX(criteria);
     }
-    return canvasRectFromCriteria(rotation, criteria, x);
+    return canvasRectFromCriteria(
+      rotation,
+      criteria,
+      x,
+      this.config.ignorePhysicalScale
+    );
   }
 
   private calculateLtrX(criteria: CanvasGroupPositionCriteria) {

--- a/libs/ngx-mime/src/lib/core/canvas-group-position/two-page-calculate-page-position-strategy.ts
+++ b/libs/ngx-mime/src/lib/core/canvas-group-position/two-page-calculate-page-position-strategy.ts
@@ -11,6 +11,7 @@ import { canvasRectFromCriteria } from './calculate-canvas-group-position-utils'
 export class TwoPageCalculateCanvasGroupPositionStrategy
   implements CalculateCanvasGroupPositionStrategy {
   constructor(private config: MimeViewerConfig) {}
+
   calculateCanvasGroupPosition(
     criteria: CanvasGroupPositionCriteria,
     rotation: number = 0

--- a/libs/ngx-mime/src/lib/core/canvas-group-position/two-page-calculate-page-position-strategy.ts
+++ b/libs/ngx-mime/src/lib/core/canvas-group-position/two-page-calculate-page-position-strategy.ts
@@ -1,14 +1,16 @@
+import { MimeViewerConfig } from '../mime-viewer-config';
 import { Rect } from '../models/rect';
 import { ViewerOptions } from '../models/viewer-options';
 import { ViewingDirection } from '../models/viewing-direction';
 import {
   CalculateCanvasGroupPositionStrategy,
-  CanvasGroupPositionCriteria
+  CanvasGroupPositionCriteria,
 } from './calculate-canvas-group-position-strategy';
 import { canvasRectFromCriteria } from './calculate-canvas-group-position-utils';
 
 export class TwoPageCalculateCanvasGroupPositionStrategy
   implements CalculateCanvasGroupPositionStrategy {
+  constructor(private config: MimeViewerConfig) {}
   calculateCanvasGroupPosition(
     criteria: CanvasGroupPositionCriteria,
     rotation: number = 0
@@ -32,7 +34,12 @@ export class TwoPageCalculateCanvasGroupPositionStrategy
           : this.calculateOddRtlX(criteria);
     }
 
-    return canvasRectFromCriteria(rotation, criteria, x);
+    return canvasRectFromCriteria(
+      rotation,
+      criteria,
+      x,
+      this.config.ignorePhysicalScale
+    );
   }
 
   private calculateEvenLtrX(criteria: CanvasGroupPositionCriteria) {

--- a/libs/ngx-mime/src/lib/core/iiif-content-search-service/iiif-content-search.service.spec.ts
+++ b/libs/ngx-mime/src/lib/core/iiif-content-search-service/iiif-content-search.service.spec.ts
@@ -13,6 +13,7 @@ import { MimeViewerConfig } from '../mime-viewer-config';
 
 describe('IiifContentSearchService', () => {
   let config: MimeViewerConfig;
+  let svc: IiifContentSearchService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -20,6 +21,8 @@ describe('IiifContentSearchService', () => {
       providers: [IiifContentSearchService],
     });
     config = new MimeViewerConfig();
+    svc = TestBed.inject(IiifContentSearchService);
+    svc.setConfig(config);
   });
 
   it('should be created', inject(
@@ -38,7 +41,6 @@ describe('IiifContentSearchService', () => {
         httpMock: HttpTestingController
       ) => {
         let result: SearchResult = new SearchResult();
-        svc.setConfig(config);
         svc.search(
           { ...new Manifest(), service: { ...new Service(), id: 'dummyUrl' } },
           'query'
@@ -76,7 +78,6 @@ describe('IiifContentSearchService', () => {
         httpMock: HttpTestingController
       ) => {
         let result!: SearchResult;
-        svc.setConfig(config);
         svc.search(new Manifest(), '');
         svc.onChange.subscribe((searchResult: SearchResult) => {
           result = searchResult;

--- a/libs/ngx-mime/src/lib/core/iiif-content-search-service/iiif-content-search.service.spec.ts
+++ b/libs/ngx-mime/src/lib/core/iiif-content-search-service/iiif-content-search.service.spec.ts
@@ -9,13 +9,17 @@ import { IiifContentSearchService } from './iiif-content-search.service';
 import { SearchResultBuilder } from './../builders/search-result.builder';
 import { SearchResult } from './../models/search-result';
 import { Manifest, Service } from './../models/manifest';
+import { MimeViewerConfig } from '../mime-viewer-config';
 
 describe('IiifContentSearchService', () => {
+  let config: MimeViewerConfig;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       providers: [IiifContentSearchService],
     });
+    config = new MimeViewerConfig();
   });
 
   it('should be created', inject(
@@ -34,7 +38,7 @@ describe('IiifContentSearchService', () => {
         httpMock: HttpTestingController
       ) => {
         let result: SearchResult = new SearchResult();
-
+        svc.setConfig(config);
         svc.search(
           { ...new Manifest(), service: { ...new Service(), id: 'dummyUrl' } },
           'query'
@@ -44,13 +48,18 @@ describe('IiifContentSearchService', () => {
         });
 
         httpMock.expectOne(`dummyUrl?q=query`).flush(
-          new SearchResultBuilder('query', new Manifest(), {
-            hits: [
-              {
-                match: 'querystring',
-              },
-            ],
-          }).build()
+          new SearchResultBuilder(
+            'query',
+            new Manifest(),
+            {
+              hits: [
+                {
+                  match: 'querystring',
+                },
+              ],
+            },
+            config
+          ).build()
         );
         tick();
         expect(result?.size()).toBe(1);
@@ -67,7 +76,7 @@ describe('IiifContentSearchService', () => {
         httpMock: HttpTestingController
       ) => {
         let result!: SearchResult;
-
+        svc.setConfig(config);
         svc.search(new Manifest(), '');
         svc.onChange.subscribe((searchResult: SearchResult) => {
           result = searchResult;

--- a/libs/ngx-mime/src/lib/core/iiif-content-search-service/iiif-content-search.service.ts
+++ b/libs/ngx-mime/src/lib/core/iiif-content-search-service/iiif-content-search.service.ts
@@ -2,6 +2,7 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, Subject, throwError } from 'rxjs';
 import { distinctUntilChanged, finalize, take } from 'rxjs/operators';
+import { MimeViewerConfig } from '../mime-viewer-config';
 import { SearchResultBuilder } from './../builders/search-result.builder';
 import { Hit } from './../models/hit';
 import { IiifSearchResult } from './../models/iiif-search-result';
@@ -17,6 +18,7 @@ export class IiifContentSearchService {
   protected _currentQ = new BehaviorSubject<string>('');
   protected _selected = new BehaviorSubject<Hit | null>(null);
 
+  private config!: MimeViewerConfig;
   constructor(private http: HttpClient) {}
 
   destroy() {
@@ -69,12 +71,21 @@ export class IiifContentSearchService {
     this._selected.next(hit);
   }
 
+  public setConfig(config: MimeViewerConfig) {
+    this.config = config;
+  }
+
   private extractData(
     q: string,
     manifest: Manifest,
     iiifSearchResult: IiifSearchResult
   ): SearchResult {
-    return new SearchResultBuilder(q, manifest, iiifSearchResult).build();
+    return new SearchResultBuilder(
+      q,
+      manifest,
+      iiifSearchResult,
+      this.config
+    ).build();
   }
 
   private handleError(err: HttpErrorResponse | any) {

--- a/libs/ngx-mime/src/lib/core/mime-viewer-config.ts
+++ b/libs/ngx-mime/src/lib/core/mime-viewer-config.ts
@@ -9,12 +9,17 @@ export class MimeViewerConfig {
   public initViewerLayout = ViewerLayout.TWO_PAGE;
   public withCredentials = false;
   public loadTilesWithAjax = false;
-  public crossOriginPolicy: 'Anonymous' | 'use-credentials' | false | undefined = false;
+  public crossOriginPolicy:
+    | 'Anonymous'
+    | 'use-credentials'
+    | false
+    | undefined = false;
   public ajaxHeaders: any = null;
   public preserveZoomOnCanvasGroupChange = false;
   public startOnTopOnCanvasGroupChange = false;
   public isDropEnabled = false;
   public initRecognizedTextContentToggle = false;
+  public ignorePhysicalScale = false;
 
   constructor(fields?: {
     attributionDialogEnabled?: boolean;
@@ -30,6 +35,7 @@ export class MimeViewerConfig {
     startOnTopOnCanvasGroupChange?: boolean;
     isDropEnabled?: boolean;
     initRecognizedTextContentToggle?: boolean;
+    ignorePhysicalScale?: boolean;
   }) {
     if (fields) {
       this.attributionDialogEnabled =
@@ -95,6 +101,11 @@ export class MimeViewerConfig {
         fields.initRecognizedTextContentToggle !== undefined
           ? fields.initRecognizedTextContentToggle
           : this.initRecognizedTextContentToggle;
+
+      this.ignorePhysicalScale =
+        fields.ignorePhysicalScale !== undefined
+          ? fields.ignorePhysicalScale
+          : this.ignorePhysicalScale;
     }
   }
 }

--- a/libs/ngx-mime/src/lib/core/utils.ts
+++ b/libs/ngx-mime/src/lib/core/utils.ts
@@ -11,7 +11,10 @@ export class Utils {
     return Number(short);
   }
 
-  static getScaleFactor(physicalScale: number | undefined): number {
-    return (physicalScale ? physicalScale : 1) * 400
+  static getScaleFactor(
+    physicalScale: number | undefined,
+    ignorePhysicalScale = false
+  ): number {
+    return ignorePhysicalScale ? 1 : (physicalScale ? physicalScale : 1) * 400;
   }
 }

--- a/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.ts
@@ -256,6 +256,7 @@ export class ViewerService {
 
   setUpViewer(manifest: Manifest, config: MimeViewerConfig) {
     this.config = config;
+    this.iiifContentSearchService.setConfig(this.config);
     if (manifest && manifest.tileSource) {
       this.tileSources = manifest.tileSource;
       this.zone.runOutsideAngular(() => {
@@ -711,7 +712,8 @@ export class ViewerService {
     const canvasRects: Rect[] = [];
     const calculateCanvasGroupPositionStrategy = CalculateCanvasGroupPositionFactory.create(
       this.viewerLayoutService.layout,
-      this.isManifestPaged
+      this.isManifestPaged,
+      this.config
     );
 
     const isTwoPageView: boolean =

--- a/libs/ngx-mime/src/lib/test/iiif-content-search-service-stub.ts
+++ b/libs/ngx-mime/src/lib/test/iiif-content-search-service-stub.ts
@@ -1,8 +1,8 @@
-import { Observable, BehaviorSubject, Subject } from 'rxjs';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
-
-import { SearchResult } from './../core/models/search-result';
+import { MimeViewerConfig } from '../..';
 import { Hit } from './../core/models/hit';
+import { SearchResult } from './../core/models/search-result';
 
 export class IiifContentSearchServiceStub {
   public _currentSearchResult: Subject<SearchResult> = new BehaviorSubject<SearchResult>(
@@ -11,6 +11,7 @@ export class IiifContentSearchServiceStub {
   public _searching = new BehaviorSubject<boolean>(false);
   public _currentQ = new BehaviorSubject<string>('');
   protected _selected = new BehaviorSubject<Hit | null>(null);
+  private config!: MimeViewerConfig;
 
   get onQChange(): Observable<string> {
     return this._currentQ.asObservable().pipe(distinctUntilChanged());
@@ -30,6 +31,10 @@ export class IiifContentSearchServiceStub {
 
   public selected(hit: Hit) {
     this._selected.next(hit);
+  }
+
+  public setConfig(config: MimeViewerConfig) {
+    this.config = config;
   }
 
   destroy() {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Utils.getScaleFactor() defaults to 400 if physicalScale is not provided.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
By setting ignorePhysicalScale in the config, Utils.getScaleFactor() defaults to 1 (i.e. no scaling).

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
