### PR TITLE
fix: search dialog not filling height of dialog with scrollable content

### DIFF
--- a/libs/ngx-mime/src/lib/content-search-dialog/content-search-dialog.component.scss
+++ b/libs/ngx-mime/src/lib/content-search-dialog/content-search-dialog.component.scss
@@ -59,6 +59,10 @@ em {
   max-width: none !important;
 }
 
+.mat-dialog-content {
+  max-height: none;
+}
+
 ::ng-deep .content-search-panel > .mat-dialog-container {
   padding: 0px !important;
   overflow: initial;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When searching for text hits on tablet/mobile it doesn't fill the height of the dialog
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #375

## What is the new behavior?
The full height of the dialog is now scrollable

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
