### PR TITLE
fix: cleanup on destroy

### DIFF
--- a/libs/ngx-mime/src/lib/core/iiif-content-search-service/iiif-content-search.service.spec.ts
+++ b/libs/ngx-mime/src/lib/core/iiif-content-search-service/iiif-content-search.service.spec.ts
@@ -3,9 +3,10 @@ import {
   HttpTestingController,
 } from '@angular/common/http/testing';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { TestManifests } from '../../../testing/test-manifests';
+import { testSearchResult } from '../../test/testSearchResult';
 import { MimeViewerConfig } from '../mime-viewer-config';
-import { SearchResultBuilder } from './../builders/search-result.builder';
-import { Manifest, Service } from './../models/manifest';
+import { Hit } from '../models/hit';
 import { SearchResult } from './../models/search-result';
 import { IiifContentSearchService } from './iiif-content-search.service';
 
@@ -36,45 +37,58 @@ describe('IiifContentSearchService', () => {
   it('should return a search result', fakeAsync(() => {
     let result: SearchResult = new SearchResult();
 
-    service.search(
-      { ...new Manifest(), service: { ...new Service(), id: 'dummyUrl' } },
-      'query'
-    );
+    service.search(TestManifests.withContentSearchService(), 'query');
     service.onChange.subscribe((searchResult: SearchResult) => {
       result = searchResult;
     });
 
-    httpTestingController.expectOne(`dummyUrl?q=query`).flush(
-      new SearchResultBuilder(
-        'query',
-        new Manifest(),
-        {
-          hits: [
-            {
-              match: 'querystring',
-            },
-          ],
-        },
-        config
-      ).build()
-    );
+    httpTestingController.expectOne(`dummyUrl?q=query`).flush(testSearchResult);
     tick();
-    expect(result?.size()).toBe(1);
+
+    expect(result?.size()).toBe(2);
   }));
 
   it('should return a empty search result if empty q', fakeAsync(() => {
     let result!: SearchResult;
 
-    service.search(new Manifest(), '');
+    service.search(TestManifests.aEmpty(), '');
     service.onChange.subscribe((searchResult: SearchResult) => {
       result = searchResult;
     });
 
     httpTestingController.expectNone(`dummyUrl?q=`);
     tick();
-    httpTestingController.verify();
+
     expect(result.size()).toBe(0);
   }));
 
-  it('should cleanup on destroy', () => {});
+  it('should cleanup on destroy', fakeAsync(() => {
+    let currentSearchResult!: SearchResult;
+    let currentQ!: string;
+    let currentIsSearching!: boolean;
+    let currentSelected!: Hit | null;
+    service.search(TestManifests.withContentSearchService(), 'fakeQuery');
+    service.isSearching.subscribe(
+      (isSearching: boolean) => (currentIsSearching = isSearching)
+    );
+    service.onQChange.subscribe((q: string) => (currentQ = q));
+    service.onChange.subscribe(
+      (searchResult: SearchResult) => (currentSearchResult = searchResult)
+    );
+    service.onSelected.subscribe(
+      (selected: Hit | null) => (currentSelected = selected)
+    );
+    httpTestingController
+      .expectOne(`dummyUrl?q=fakeQuery`)
+      .flush(testSearchResult);
+    service.selected(new Hit());
+
+    service.destroy();
+
+    expect(currentSelected).toBeNull();
+    expect(currentIsSearching).toBeFalsy();
+    expect(currentQ).toBe('');
+    expect(currentSearchResult.q).toEqual('');
+    expect(currentSearchResult.hits.length).toBe(0);
+  }));
 });

--- a/libs/ngx-mime/src/lib/core/iiif-content-search-service/iiif-content-search.service.spec.ts
+++ b/libs/ngx-mime/src/lib/core/iiif-content-search-service/iiif-content-search.service.spec.ts
@@ -1,15 +1,13 @@
-import { fakeAsync, inject, TestBed, tick } from '@angular/core/testing';
 import {
   HttpClientTestingModule,
   HttpTestingController,
 } from '@angular/common/http/testing';
-import { HttpClient } from '@angular/common/http';
-
-import { IiifContentSearchService } from './iiif-content-search.service';
-import { SearchResultBuilder } from './../builders/search-result.builder';
-import { SearchResult } from './../models/search-result';
-import { Manifest, Service } from './../models/manifest';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { MimeViewerConfig } from '../mime-viewer-config';
+import { SearchResultBuilder } from './../builders/search-result.builder';
+import { Manifest, Service } from './../models/manifest';
+import { SearchResult } from './../models/search-result';
+import { IiifContentSearchService } from './iiif-content-search.service';
 
 describe('IiifContentSearchService', () => {
   let httpTestingController: HttpTestingController;

--- a/libs/ngx-mime/src/lib/core/iiif-content-search-service/iiif-content-search.service.ts
+++ b/libs/ngx-mime/src/lib/core/iiif-content-search-service/iiif-content-search.service.ts
@@ -23,6 +23,8 @@ export class IiifContentSearchService {
 
   destroy() {
     this._currentSearchResult.next(new SearchResult({}));
+    this._searching.next(false);
+    this._currentQ.next('');
     this._selected.next(null);
   }
 

--- a/libs/ngx-mime/src/testing/index.ts
+++ b/libs/ngx-mime/src/testing/index.ts
@@ -1,0 +1,1 @@
+export { TestManifests } from './test-manifests';

--- a/libs/ngx-mime/src/testing/test-manifests.ts
+++ b/libs/ngx-mime/src/testing/test-manifests.ts
@@ -1,0 +1,12 @@
+import { Manifest, Service } from '../lib/core/models/manifest';
+
+export class TestManifests {
+
+  public static aEmpty(): Manifest {
+    return { ...new Manifest(), service: { ...new Service(), id: 'dummyUrl' } };
+  }
+
+  public static withContentSearchService(): Manifest {
+    return { ...new Manifest(), service: { ...new Service(), id: 'dummyUrl' } };
+  }
+}

--- a/libs/ngx-mime/src/testing/test-manifests.ts
+++ b/libs/ngx-mime/src/testing/test-manifests.ts
@@ -1,9 +1,8 @@
 import { Manifest, Service } from '../lib/core/models/manifest';
 
 export class TestManifests {
-
   public static aEmpty(): Manifest {
-    return { ...new Manifest(), service: { ...new Service(), id: 'dummyUrl' } };
+    return new Manifest();
   }
 
   public static withContentSearchService(): Manifest {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[X] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
NGX-Mime does not reset current q on destroy 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
q is reset to an empty string when IiifContentSearchService is destroyed

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
