### PR TITLE
fix: npe

### DIFF
--- a/libs/ngx-mime/src/lib/core/mode-service/mode.service.ts
+++ b/libs/ngx-mime/src/lib/core/mode-service/mode.service.ts
@@ -53,7 +53,11 @@ export class ModeService {
   }
 
   isPageZoomed(): boolean {
-    return this.mode  === ViewerMode.PAGE_ZOOMED
+    return this.mode === ViewerMode.PAGE_ZOOMED;
+  }
+
+  destroy() {
+    this.mode = this._initialMode;
   }
 
   private change() {

--- a/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.ts
@@ -437,6 +437,7 @@ export class ViewerService {
       this.currentSearch = null;
       this.iiifContentSearchService.destroy();
       this.rotation.next(0);
+      this.modeService.destroy();
       this.unsubscribe();
     }
   }
@@ -499,6 +500,10 @@ export class ViewerService {
    * @param mode ViewerMode
    */
   modeChanged(mode: ModeChanges): void {
+    if (!this.viewer) {
+      return;
+    }
+
     if (mode.currentValue === ViewerMode.DASHBOARD) {
       this.viewer.panVertical = false;
       this.toggleToDashboard();

--- a/libs/ngx-mime/src/lib/core/viewer-service/zoom-strategy.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/zoom-strategy.ts
@@ -66,7 +66,7 @@ export class ZoomStrategy {
   }
 
   private getHomeZoomLevel(mode: ViewerMode): number {
-    if (!this.viewer || !this.canvasService) {
+    if (!this.viewer || !this.canvasService || !this.viewer.container) {
       return 1;
     }
 
@@ -135,10 +135,6 @@ export class ZoomStrategy {
   }
 
   private getDashboardViewportBounds(): any {
-    if (!this.viewer) {
-      return;
-    }
-
     const homeZoomFactor = this.getHomeZoomFactor();
     const maxViewportDimensions = new Dimensions(
       d3


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

1. Open manifest
2. Go to dashboard mode
3. Change page
3. Change manifest

ERROR TypeError: Cannot read properties of null (reading 'parentNode')
    at Ate.getDashboardViewportBounds (main.js:1:720975)
    at Ate.getHomeZoomLevel (main.js:1:720244)
    at Ate.goToHomeZoom (main.js:1:719910)
    at L._next (main.js:1:737665)
    at L.__tryOrUnsub (main.js:1:5405)
    at L.next (main.js:1:4650)
    at S._next (main.js:1:3849)
    at S.next (main.js:1:3623)
    at $Z._next (main.js:1:429148)
    at $Z.next (main.js:1:3623)

1. Open manifest
2. Change manifest

ERROR TypeError: Cannot set properties of null (setting 'panVertical')
    at n.modeChanged (main.js:1:740853)
    at L._next (main.js:1:737150)
    at L.__tryOrUnsub (main.js:1:5405)
    at L.next (main.js:1:4650)
    at S._next (main.js:1:3849)
    at S.next (main.js:1:3623)
    at $Z._next (main.js:1:429148)
    at $Z.next (main.js:1:3623)
    at Cn.next (main.js:1:8285)
    at Cn.next (main.js:1:376027)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

No errors

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
