### PR TITLE
fix: Modern "ios" devices report as Macintosh, so disable canvas also…

### DIFF
--- a/libs/ngx-mime/src/lib/core/viewer-service/options.factory.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/options.factory.ts
@@ -1,16 +1,17 @@
+import * as OpenSeadragon from 'openseadragon';
 import { MimeViewerConfig } from '../mime-viewer-config';
 import { ViewerOptions } from '../models/viewer-options';
-import * as OpenSeadragon from 'openseadragon';
 
 export class OptionsFactory {
   public static create(
     mimeViewerConfig: MimeViewerConfig
   ): OpenSeadragon.Options {
     let options: OpenSeadragon.Options = OpenSeadragon.DEFAULT_SETTINGS;
+
     return {
       ...options,
       id: 'openseadragon',
-      useCanvas: !options.iOSDevice,
+      useCanvas: this.canUseCanvas(),
       panVertical: true,
       minZoomImageRatio: 1,
       maxZoomPixelRatio: 5,
@@ -46,5 +47,21 @@ export class OptionsFactory {
         flickEnabled: false,
       },
     };
+  }
+
+  private static canUseCanvas() {
+    if (typeof navigator !== 'object') {
+      return false;
+    }
+    const userAgent = navigator.userAgent;
+    if (typeof userAgent !== 'string') {
+      return false;
+    }
+    return !(
+      userAgent.indexOf('iPhone') !== -1 ||
+      userAgent.indexOf('iPad') !== -1 ||
+      userAgent.indexOf('iPod') !== -1 ||
+      userAgent.indexOf('Macintosh') !== -1
+    );
   }
 }


### PR DESCRIPTION
… for Mac

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Modern Apple devices reports as Macintosh rather than iPad/iPhone/iPod, but canvas size is still limited based on device screen size.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Use SVG for all Apple devices (including desktop)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
