### PR TITLE
fix: various bugs with dialogs and change detection

### DIFF
--- a/libs/ngx-mime/src/lib/canvas-group-dialog/canvas-group-dialog.service.ts
+++ b/libs/ngx-mime/src/lib/canvas-group-dialog/canvas-group-dialog.service.ts
@@ -3,14 +3,13 @@ import {
   MatDialog,
   MatDialogConfig,
   MatDialogRef,
+  MatDialogState,
 } from '@angular/material/dialog';
-import { take } from 'rxjs/operators';
 import { CanvasGroupDialogComponent } from './canvas-group-dialog.component';
 
 @Injectable()
 export class CanvasGroupDialogService {
-  private isCanvasGroupDialogOpen = false;
-  private dialogRef: MatDialogRef<CanvasGroupDialogComponent> | null = null;
+  private dialogRef?: MatDialogRef<CanvasGroupDialogComponent>;
 
   constructor(private dialog: MatDialog) {}
 
@@ -20,29 +19,25 @@ export class CanvasGroupDialogService {
     this.close();
   }
 
-  public open(timeout?: number): void {
-    if (!this.isCanvasGroupDialogOpen) {
+  public open(): void {
+    if (!this.isOpen()) {
       const config = this.getDialogConfig();
       this.dialogRef = this.dialog.open(CanvasGroupDialogComponent, config);
-      this.dialogRef
-        .afterClosed()
-        .pipe(take(1))
-        .subscribe((result) => {
-          this.isCanvasGroupDialogOpen = false;
-        });
-      this.isCanvasGroupDialogOpen = true;
     }
   }
 
   public close(): void {
-    if (this.dialogRef) {
-      this.dialogRef.close();
-      this.isCanvasGroupDialogOpen = false;
+    if (this.isOpen()) {
+      this.dialogRef?.close();
     }
   }
 
   public toggle(): void {
-    this.isCanvasGroupDialogOpen ? this.close() : this.open();
+    this.isOpen() ? this.close() : this.open();
+  }
+
+  public isOpen(): boolean {
+    return this.dialogRef?.getState() === MatDialogState.OPEN;
   }
 
   private getDialogConfig(): MatDialogConfig {

--- a/libs/ngx-mime/src/lib/content-search-dialog/content-search-dialog.service.ts
+++ b/libs/ngx-mime/src/lib/content-search-dialog/content-search-dialog.service.ts
@@ -3,9 +3,9 @@ import {
   MatDialog,
   MatDialogConfig,
   MatDialogRef,
+  MatDialogState,
 } from '@angular/material/dialog';
 import { Subscription } from 'rxjs';
-import { take } from 'rxjs/operators';
 import { MimeResizeService } from './../core/mime-resize-service/mime-resize.service';
 import { ContentSearchDialogConfigStrategyFactory } from './content-search-dialog-config-strategy-factory';
 import { ContentSearchDialogComponent } from './content-search-dialog.component';
@@ -13,7 +13,6 @@ import { ContentSearchDialogComponent } from './content-search-dialog.component'
 @Injectable()
 export class ContentSearchDialogService {
   private _el: ElementRef | null = null;
-  private isContentSearchDialogOpen = false;
   private dialogRef!: MatDialogRef<ContentSearchDialogComponent>;
   private subscriptions!: Subscription;
 
@@ -27,7 +26,7 @@ export class ContentSearchDialogService {
     this.subscriptions = new Subscription();
     this.subscriptions.add(
       this.mimeResizeService.onResize.subscribe((rect) => {
-        if (this.isContentSearchDialogOpen) {
+        if (this.isOpen()) {
           const config = this.getDialogConfig();
           this.dialogRef.updatePosition(config.position);
           this.dialogRef.updateSize(config.width, config.height);
@@ -46,32 +45,24 @@ export class ContentSearchDialogService {
   }
 
   public open() {
-    if (!this.isContentSearchDialogOpen) {
+    if (!this.isOpen()) {
       const config = this.getDialogConfig();
       this.dialogRef = this.dialog.open(ContentSearchDialogComponent, config);
-      this.dialogRef
-        .afterClosed()
-        .pipe(take(1))
-        .subscribe((result) => {
-          this.isContentSearchDialogOpen = false;
-        });
-      this.isContentSearchDialogOpen = true;
     }
   }
 
   public close() {
-    if (this.dialogRef) {
+    if (this.isOpen()) {
       this.dialogRef.close();
     }
-    this.isContentSearchDialogOpen = false;
   }
 
   public toggle() {
-    this.isContentSearchDialogOpen ? this.close() : this.open();
+    this.isOpen() ? this.close() : this.open();
   }
 
   public isOpen(): boolean {
-    return this.isContentSearchDialogOpen;
+    return this.dialogRef?.getState() === MatDialogState.OPEN;
   }
 
   private getDialogConfig(): MatDialogConfig {

--- a/libs/ngx-mime/src/lib/content-search-dialog/content-search-dialog.service.ts
+++ b/libs/ngx-mime/src/lib/content-search-dialog/content-search-dialog.service.ts
@@ -13,7 +13,7 @@ import { ContentSearchDialogComponent } from './content-search-dialog.component'
 @Injectable()
 export class ContentSearchDialogService {
   private _el: ElementRef | null = null;
-  private dialogRef!: MatDialogRef<ContentSearchDialogComponent>;
+  private dialogRef?: MatDialogRef<ContentSearchDialogComponent>;
   private subscriptions!: Subscription;
 
   constructor(
@@ -28,14 +28,14 @@ export class ContentSearchDialogService {
       this.mimeResizeService.onResize.subscribe((rect) => {
         if (this.isOpen()) {
           const config = this.getDialogConfig();
-          this.dialogRef.updatePosition(config.position);
-          this.dialogRef.updateSize(config.width, config.height);
+          this.dialogRef?.updatePosition(config.position);
+          this.dialogRef?.updateSize(config.width, config.height);
         }
       })
     );
   }
 
-  public destroy() {
+  public destroy(): void {
     this.close();
     this.unsubscribe();
   }
@@ -44,20 +44,20 @@ export class ContentSearchDialogService {
     this._el = el;
   }
 
-  public open() {
+  public open(): void {
     if (!this.isOpen()) {
       const config = this.getDialogConfig();
       this.dialogRef = this.dialog.open(ContentSearchDialogComponent, config);
     }
   }
 
-  public close() {
+  public close(): void {
     if (this.isOpen()) {
-      this.dialogRef.close();
+      this.dialogRef?.close();
     }
   }
 
-  public toggle() {
+  public toggle(): void {
     this.isOpen() ? this.close() : this.open();
   }
 

--- a/libs/ngx-mime/src/lib/help-dialog/help-dialog.service.ts
+++ b/libs/ngx-mime/src/lib/help-dialog/help-dialog.service.ts
@@ -1,7 +1,10 @@
 import { ElementRef, Injectable } from '@angular/core';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import {
+  MatDialog,
+  MatDialogRef,
+  MatDialogState,
+} from '@angular/material/dialog';
 import { Subscription } from 'rxjs';
-import { take } from 'rxjs/operators';
 import { MimeResizeService } from '../core/mime-resize-service/mime-resize.service';
 import { HelpDialogConfigStrategyFactory } from './help-dialog-config-strategy-factory';
 import { HelpDialogComponent } from './help-dialog.component';
@@ -9,8 +12,7 @@ import { HelpDialogComponent } from './help-dialog.component';
 @Injectable()
 export class HelpDialogService {
   private _el: ElementRef | null = null;
-  private isHelpDialogOpen = false;
-  private dialogRef!: MatDialogRef<HelpDialogComponent>;
+  private dialogRef?: MatDialogRef<HelpDialogComponent>;
   private subscriptions!: Subscription;
 
   constructor(
@@ -23,10 +25,10 @@ export class HelpDialogService {
     this.subscriptions = new Subscription();
     this.subscriptions.add(
       this.mimeResizeService.onResize.subscribe(() => {
-        if (this.isHelpDialogOpen) {
+        if (this.isOpen()) {
           const config = this.getDialogConfig();
-          this.dialogRef.updatePosition(config.position);
-          this.dialogRef.updateSize(config.width, config.height);
+          this.dialogRef?.updatePosition(config.position);
+          this.dialogRef?.updateSize(config.width, config.height);
         }
       })
     );
@@ -42,32 +44,24 @@ export class HelpDialogService {
   }
 
   public open(): void {
-    if (!this.isHelpDialogOpen) {
+    if (!this.isOpen()) {
       const config = this.getDialogConfig();
       this.dialogRef = this.dialog.open(HelpDialogComponent, config);
-      this.dialogRef
-        .afterClosed()
-        .pipe(take(1))
-        .subscribe(() => {
-          this.isHelpDialogOpen = false;
-        });
-      this.isHelpDialogOpen = true;
     }
   }
 
   public close(): void {
-    if (this.dialogRef) {
-      this.dialogRef.close();
+    if (this.isOpen()) {
+      this.dialogRef?.close();
     }
-    this.isHelpDialogOpen = false;
   }
 
   public toggle(): void {
-    this.isHelpDialogOpen ? this.close() : this.open();
+    this.isOpen() ? this.close() : this.open();
   }
 
   public isOpen(): boolean {
-    return this.isHelpDialogOpen;
+    return this.dialogRef?.getState() === MatDialogState.OPEN;
   }
 
   private getDialogConfig() {

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.ts
@@ -246,7 +246,9 @@ export class ViewerComponent
             }
           });
         }
-        this.viewerModeChanged.emit(mode.currentValue);
+        this.zone.run(() => {
+          this.viewerModeChanged.emit(mode.currentValue);
+        });
       })
     );
 

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.ts
@@ -12,7 +12,6 @@ import {
   OnDestroy,
   OnInit,
   Output,
-  SimpleChange,
   SimpleChanges,
   ViewChild,
   ViewContainerRef,
@@ -296,56 +295,26 @@ export class ViewerComponent
         }
       )
     );
-
-    this.loadManifest();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    let manifestUriIsChanged = false;
-    let qIsChanged = false;
-    let canvasIndexChanged = false;
-    if (changes['q']) {
-      const qChanges: SimpleChange = changes['q'];
-      if (
-        !qChanges.isFirstChange() &&
-        qChanges.currentValue !== qChanges.firstChange
-      ) {
-        this.q = qChanges.currentValue;
-        qIsChanged = true;
-      }
-    }
-    if (changes['canvasIndex']) {
-      const canvasIndexChanges: SimpleChange = changes['canvasIndex'];
-      if (
-        !canvasIndexChanges.isFirstChange() &&
-        canvasIndexChanges.currentValue !== canvasIndexChanges.firstChange
-      ) {
-        this.canvasIndex = canvasIndexChanges.currentValue;
-        canvasIndexChanged = true;
-      }
-    }
     if (changes['manifestUri']) {
-      const manifestUriChanges: SimpleChange = changes['manifestUri'];
-      if (!manifestUriChanges.isFirstChange()) {
-        this.cleanup();
-      }
-      if (
-        !manifestUriChanges.isFirstChange() &&
-        manifestUriChanges.currentValue !== manifestUriChanges.previousValue
-      ) {
-        this.modeService.mode = this.config.initViewerMode;
-        this.manifestUri = manifestUriChanges.currentValue;
-        manifestUriIsChanged = true;
+      this.cleanup();
+      this.modeService.mode = this.config.initViewerMode;
+      this.manifestUri = changes['manifestUri'].currentValue;
+      this.loadManifest();
+    }
+
+    if (changes['q']) {
+      this.q = changes['q'].currentValue;
+      if (this.currentManifest) {
+        this.iiifContentSearchService.search(this.currentManifest, this.q);
       }
     }
 
-    if (manifestUriIsChanged) {
-      this.loadManifest();
-    } else {
-      if (qIsChanged && this.currentManifest) {
-        this.iiifContentSearchService.search(this.currentManifest, this.q);
-      }
-      if (canvasIndexChanged) {
+    if (changes['canvasIndex']) {
+      this.canvasIndex = changes['canvasIndex'].currentValue;
+      if (this.currentManifest) {
         this.viewerService.goToCanvas(this.canvasIndex, true);
       }
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
ng-mime doesn't always tear down all dialog services and calls user provided emitter outside ngZone

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Dialog services always close and unsubscribe before loading a new manifest.
Dialog services use getState() to determine state instead of callbacks
viewerModeChanged emitter is run in ngZone


## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
