### PR TITLE
fix: make highlighting compatible with firefox & safari

### DIFF
--- a/libs/ngx-mime/src/lib/viewer/viewer.component.scss
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.scss
@@ -83,7 +83,6 @@
 
 .navbar-header {
   top: 0;
-  width: 100%;
 }
 
 .navbar-footer {

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.scss
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.scss
@@ -90,10 +90,6 @@
   bottom: 0;
 }
 
-::ng-deep .cdk-overlay-container {
-  z-index: 2147483647;
-}
-
 .error-container {
   width: 100%;
   height: 100%;

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.scss
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.scss
@@ -60,9 +60,12 @@
   stroke: rgba(0, 0, 0, 0.45);
 }
 
+::ng-deep .viewer-container svg {
+  mix-blend-mode: multiply;
+}
+
 ::ng-deep .viewer-container .hit {
   fill: #ffff00;
-  mix-blend-mode: multiply;
 }
 
 ::ng-deep .viewer-container .selected {

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.scss
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.scss
@@ -6,19 +6,59 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-}
 
-:host::ng-deep.openseadragon-container {
-  flex-grow: 1;
-}
+  &.mode-page-zoomed::ng-deep.tile:hover {
+    cursor: -webkit-grab;
+  }
 
-:host::ng-deep.openseadragon-canvas:focus {
-  outline: none;
-}
+  &.canvas-pressed,
+  &.canvas-pressed::ng-deep.tile:hover {
+    cursor: grabbing;
+    cursor: -webkit-grabbing;
+  }
 
-.viewer-drawer-container {
-  width: 100%;
-  height: 100%;
+  &.mode-dashboard {
+    &.layout-one-page::ng-deep.tile,
+    &.layout-two-page::ng-deep.page-group .tile {
+      stroke: rgba(0, 0, 0, 0.15);
+      stroke-width: 8;
+      transition: 0.25s ease stroke;
+    }
+
+    &.layout-one-page::ng-deep.tile:hover,
+    &.layout-two-page::ng-deep.page-group:hover .tile {
+      stroke: rgba(0, 0, 0, 0.45);
+    }
+  }
+
+  ::ng-deep {
+    .openseadragon-container {
+      flex-grow: 1;
+    }
+    .openseadragon-canvas:focus {
+      outline: none;
+    }
+    .tile {
+      cursor: pointer;
+      fill-opacity: 0;
+    }
+    .hit {
+      fill: #ffff00;
+    }
+    .selected {
+      fill: #ff8900;
+      stroke: rgb(97, 52, 0);
+      stroke-width: 4px;
+    }
+    svg {
+      mix-blend-mode: multiply;
+    }
+  }
+
+  .viewer-drawer-container {
+    width: 100%;
+    height: 100%;
+  }
 }
 
 #openseadragon {
@@ -28,50 +68,6 @@
   opacity: 0;
   width: 100%;
   height: 100%;
-}
-
-::ng-deep .viewer-container.mode-page-zoomed .tile:hover {
-  cursor: -webkit-grab;
-}
-
-.viewer-container.canvas-pressed,
-.viewer-container.canvas-pressed::ng-deep.tile:hover {
-  cursor: grabbing;
-  cursor: -webkit-grabbing;
-}
-
-::ng-deep .viewer-container .tile {
-  cursor: pointer;
-  fill-opacity: 0;
-}
-
-::ng-deep .viewer-container.mode-dashboard.layout-one-page .tile,
-::ng-deep .viewer-container.mode-dashboard.layout-two-page .page-group .tile {
-  stroke: rgba(0, 0, 0, 0.15);
-  stroke-width: 8;
-  transition: 0.25s ease stroke;
-}
-
-::ng-deep .viewer-container.mode-dashboard.layout-one-page .tile:hover,
-::ng-deep
-  .viewer-container.mode-dashboard.layout-two-page
-  .page-group:hover
-  .tile {
-  stroke: rgba(0, 0, 0, 0.45);
-}
-
-::ng-deep .viewer-container svg {
-  mix-blend-mode: multiply;
-}
-
-::ng-deep .viewer-container .hit {
-  fill: #ffff00;
-}
-
-::ng-deep .viewer-container .selected {
-  fill: #ff8900;
-  stroke: rgb(97, 52, 0);
-  stroke-width: 4px;
 }
 
 .navbar {

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.scss
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.scss
@@ -31,6 +31,18 @@
     }
   }
 
+  &.broken-mix-blend-mode {
+    ::ng-deep {
+      .hit {
+        mix-blend-mode: unset !important;
+        fill: #ffff0099;
+      }
+      .selected {
+        fill: #ff890099;
+      }
+    }
+  }
+
   ::ng-deep {
     .openseadragon-container {
       flex-grow: 1;
@@ -43,15 +55,13 @@
       fill-opacity: 0;
     }
     .hit {
+      mix-blend-mode: multiply;
       fill: #ffff00;
     }
     .selected {
       fill: #ff8900;
       stroke: rgb(97, 52, 0);
       stroke-width: 4px;
-    }
-    svg {
-      mix-blend-mode: multiply;
     }
   }
 

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.ts
@@ -463,10 +463,7 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   private hasMixBlendModeSupport(): boolean {
-    return !(
-      this.platform.FIREFOX ||
-      (this.platform.SAFARI && !this.platform.IOS)
-    );
+    return !(this.platform.FIREFOX || this.platform.SAFARI);
   }
 
   goToHomeZoom(): void {

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.ts
@@ -1,3 +1,4 @@
+import { Platform } from '@angular/cdk/platform';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -109,7 +110,8 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
     private viewerLayoutService: ViewerLayoutService,
     private styleService: StyleService,
     private altoService: AltoService,
-    public zone: NgZone
+    public zone: NgZone,
+    public platform: Platform
   ) {
     contentsDialogService.el = el;
     attributionDialogService.el = el;
@@ -460,6 +462,13 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
     this.errorMessage = null;
   }
 
+  private hasMixBlendModeSupport(): boolean {
+    return !(
+      this.platform.FIREFOX ||
+      (this.platform.SAFARI && !this.platform.IOS)
+    );
+  }
+
   goToHomeZoom(): void {
     if (this.recognizedTextContentMode !== this.recognizedTextMode.ONLY) {
       this.viewerService.goToHomeZoom();
@@ -474,6 +483,7 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
       'layout-one-page': this.viewerLayout === ViewerLayout.ONE_PAGE,
       'layout-two-page': this.viewerLayout === ViewerLayout.TWO_PAGE,
       'canvas-pressed': this.isCanvasPressed,
+      'broken-mix-blend-mode': !this.hasMixBlendModeSupport(),
     };
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Highlighting of search hits are fully opaque in Firefox and Safari

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Highlighting looks as intended in Firefox and Safari

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
