### PR TITLE
fix: contents-dialog should now resize on objects without toc

### DIFF
--- a/libs/ngx-mime/src/lib/contents-dialog/contents-dialog.component.ts
+++ b/libs/ngx-mime/src/lib/contents-dialog/contents-dialog.component.ts
@@ -5,7 +5,7 @@ import {
   ElementRef,
   HostListener,
   OnDestroy,
-  OnInit,
+  OnInit
 } from '@angular/core';
 import { MediaObserver } from '@angular/flex-layout';
 import { MatDialogRef } from '@angular/material/dialog';
@@ -21,7 +21,7 @@ import { Manifest } from './../core/models/manifest';
   selector: 'mime-contents',
   templateUrl: './contents-dialog.component.html',
   styleUrls: ['./contents-dialog.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ContentsDialogComponent implements OnInit, OnDestroy {
   public manifest: Manifest | null = null;
@@ -58,7 +58,6 @@ export class ContentsDialogComponent implements OnInit, OnDestroy {
             this.manifest !== null &&
             this.manifest.structures !== undefined &&
             this.manifest.structures.length > 0;
-          this.changeDetectorRef.detectChanges();
         }
       )
     );
@@ -82,19 +81,18 @@ export class ContentsDialogComponent implements OnInit, OnDestroy {
   }
 
   private resizeTabHeight(): void {
-    const dimensions = this.mimeDomHelper.getBoundingClientRect(this.el);
     let height = this.mimeHeight;
 
     if (this.mediaObserver.isActive('lt-md')) {
-      height -= 104;
       this.tabHeight = {
-        maxHeight: window.innerHeight - 128 + 'px',
+        maxHeight: window.innerHeight - 128 + 'px'
       };
     } else {
       height -= 278;
       this.tabHeight = {
-        maxHeight: height + 'px',
+        maxHeight: height + 'px'
       };
     }
+    this.changeDetectorRef.markForCheck();
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

If content dialog stretches longer than viewport it doesn't resize if it's an object without toc, until a CD is triggered by hovering the close button

Issue Number: N/A

## What is the new behavior?
contents dialog now correctly resizes on objects without toc

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
