### PR TITLE
fix(a11y): applied the role="group" to convey the association between the individual toggles

### DIFF
--- a/libs/ngx-mime/src/lib/view-dialog/view-dialog.component.html
+++ b/libs/ngx-mime/src/lib/view-dialog/view-dialog.component.html
@@ -38,31 +38,34 @@
   <ng-container *ngIf="isPagedManifest">
     <section data-test-id="page-layout">
       <h2>{{ intl.pageLayoutLabel }}</h2>
-      <div fxLayout="column" fxLayoutGap="8px">
+      <div
+        fxLayout="column"
+        fxLayoutGap="8px"
+        role="group"
+        [ariaLabel]="intl.pageLayoutLabel"
+      >
         <div fxLayout="row" fxLayoutAlign="start center">
-          <mat-button-toggle-group [value]="viewerLayout">
-            <mat-button-toggle
-              data-test-id="ngx-mime-single-page-view-button"
-              [aria-label]="intl.singlePageViewLabel"
-              [value]="ViewerLayout.ONE_PAGE"
-              (click)="setLayoutOnePage()"
-            >
-              <mime-icon [iconName]="'single_page_display'"> </mime-icon>
-            </mat-button-toggle>
-          </mat-button-toggle-group>
+          <mat-button-toggle
+            data-test-id="ngx-mime-single-page-view-button"
+            [aria-label]="intl.singlePageViewLabel"
+            [value]="ViewerLayout.ONE_PAGE"
+            [checked]="viewerLayout === ViewerLayout.ONE_PAGE"
+            (click)="setLayoutOnePage()"
+          >
+            <mime-icon [iconName]="'single_page_display'"> </mime-icon>
+          </mat-button-toggle>
           <div class="label">{{ intl.singlePageViewLabel }}</div>
         </div>
         <div fxLayout="row" fxLayoutAlign="start center">
-          <mat-button-toggle-group [value]="viewerLayout">
-            <mat-button-toggle
-              data-test-id="ngx-mime-two-page-view-button"
-              [aria-label]="intl.twoPageViewLabel"
-              [value]="ViewerLayout.TWO_PAGE"
-              (click)="setLayoutTwoPage()"
-            >
-              <mime-icon [iconName]="'two_page_display'"> </mime-icon>
-            </mat-button-toggle>
-          </mat-button-toggle-group>
+          <mat-button-toggle
+            data-test-id="ngx-mime-two-page-view-button"
+            [aria-label]="intl.twoPageViewLabel"
+            [value]="ViewerLayout.TWO_PAGE"
+            [checked]="viewerLayout === ViewerLayout.TWO_PAGE"
+            (click)="setLayoutTwoPage()"
+          >
+            <mime-icon [iconName]="'two_page_display'"> </mime-icon>
+          </mat-button-toggle>
           <div class="label">{{ intl.twoPageViewLabel }}</div>
         </div>
       </div>
@@ -72,46 +75,48 @@
     <mat-divider></mat-divider>
     <section data-test-id="recognized-text-content">
       <h2>{{ intl.digitalTextLabel }}</h2>
-      <div fxLayout="column" fxLayoutGap="8px">
+      <div
+        fxLayout="column"
+        fxLayoutGap="8px"
+        role="group"
+        [ariaLabel]="intl.digitalTextLabel"
+      >
         <div fxLayout="row" fxLayoutAlign="start center">
-          <mat-button-toggle-group [value]="recognizedTextMode">
-            <mat-button-toggle
-              data-test-id="ngx-mime-recognized-text-content-close-button"
-              [aria-label]="intl.recognizedTextContentCloseLabel"
-              [value]="RecognizedTextMode.NONE"
-              (click)="closeRecognizedTextContent()"
-            >
-              <mat-icon>hide_source</mat-icon>
-            </mat-button-toggle>
-          </mat-button-toggle-group>
+          <mat-button-toggle
+            data-test-id="ngx-mime-recognized-text-content-close-button"
+            [aria-label]="intl.recognizedTextContentCloseLabel"
+            [value]="RecognizedTextMode.NONE"
+            [checked]="recognizedTextMode === RecognizedTextMode.NONE"
+            (click)="closeRecognizedTextContent()"
+          >
+            <mat-icon>hide_source</mat-icon>
+          </mat-button-toggle>
           <div class="label">{{ intl.recognizedTextContentCloseLabel }}</div>
         </div>
         <div fxLayout="row" fxLayoutAlign="start center">
-          <mat-button-toggle-group [value]="recognizedTextMode">
-            <mat-button-toggle
-              data-test-id="ngx-mime-recognized-text-content-split-view-button"
-              [aria-label]="intl.recognizedTextContentInSplitViewLabel"
-              [value]="RecognizedTextMode.SPLIT"
-              (click)="showRecognizedTextContentInSplitView()"
-            >
-              <mat-icon>view_sidebar</mat-icon>
-            </mat-button-toggle>
-          </mat-button-toggle-group>
+          <mat-button-toggle
+            data-test-id="ngx-mime-recognized-text-content-split-view-button"
+            [aria-label]="intl.recognizedTextContentInSplitViewLabel"
+            [value]="RecognizedTextMode.SPLIT"
+            [checked]="recognizedTextMode === RecognizedTextMode.SPLIT"
+            (click)="showRecognizedTextContentInSplitView()"
+          >
+            <mat-icon>view_sidebar</mat-icon>
+          </mat-button-toggle>
           <div class="label">{{
             intl.recognizedTextContentInSplitViewLabel
           }}</div>
         </div>
         <div fxLayout="row" fxLayoutAlign="start center">
-          <mat-button-toggle-group [value]="recognizedTextMode">
-            <mat-button-toggle
-              data-test-id="ngx-mime-recognized-text-content-only-button"
-              [aria-label]="intl.showRecognizedTextContentLabel"
-              [value]="RecognizedTextMode.ONLY"
-              (click)="showRecognizedTextContentOnly()"
-            >
-              <mat-icon>article</mat-icon>
-            </mat-button-toggle>
-          </mat-button-toggle-group>
+          <mat-button-toggle
+            data-test-id="ngx-mime-recognized-text-content-only-button"
+            [aria-label]="intl.showRecognizedTextContentLabel"
+            [value]="RecognizedTextMode.ONLY"
+            [checked]="recognizedTextMode === RecognizedTextMode.ONLY"
+            (click)="showRecognizedTextContentOnly()"
+          >
+            <mat-icon>article</mat-icon>
+          </mat-button-toggle>
           <div class="label">{{ intl.showRecognizedTextContentLabel }}</div>
         </div>
       </div>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #446 

## What is the new behavior?
Added a role="group" with aria-label around the toggle buttons. This aria label will be read by screen readers when users is on toggle button

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
