### PR TITLE
fix: update currentHit when searchResult is updated

### DIFF
--- a/libs/ngx-mime/src/lib/core/navigation/content-search-navigation-service/content-search-navigation.service.spec.ts
+++ b/libs/ngx-mime/src/lib/core/navigation/content-search-navigation-service/content-search-navigation.service.spec.ts
@@ -127,6 +127,18 @@ describe('ContentSearchNavigationService', () => {
     })
   );
 
+  it('should reset currentHitCounter when searchresult is updated', waitForAsync(() => {
+    contentSearchNavigationService.update(12);
+
+    contentSearchNavigationService.currentHitCounter.subscribe((hit) => {
+      expect(hit).toBe(-1);
+    });
+
+    const updatedSearchResult = createSearchResult();
+    updatedSearchResult.add(new Hit({ id: 7, index: 10 }));
+    iiifContentSearchServiceStub._currentSearchResult.next(updatedSearchResult);
+  }));
+
   function createCanvasGroups(): Rect[] {
     const canvasGroups: Rect[] = [];
     for (let i = 0; i < 100; i++) {

--- a/libs/ngx-mime/src/lib/core/navigation/content-search-navigation-service/content-search-navigation.service.spec.ts
+++ b/libs/ngx-mime/src/lib/core/navigation/content-search-navigation-service/content-search-navigation.service.spec.ts
@@ -57,87 +57,67 @@ describe('ContentSearchNavigationService', () => {
     expect(contentSearchNavigationService).toBeTruthy();
   });
 
-  it(
-    'should go to next hit',
-    waitForAsync(() => {
-      contentSearchNavigationService.update(6);
+  it('should go to next hit', waitForAsync(() => {
+    contentSearchNavigationService.update(6);
 
-      contentSearchNavigationService.currentHitCounter.subscribe((hitId) => {
-        expect(hitId).toBe(6);
-      });
+    contentSearchNavigationService.currentHitCounter.subscribe((hitId) => {
+      expect(hitId).toBe(6);
+    });
 
-      contentSearchNavigationService.goToNextHit();
-    })
-  );
+    contentSearchNavigationService.goToNextHit();
+  }));
 
-  it(
-    'should go to previous hit',
-    waitForAsync(() => {
-      contentSearchNavigationService.update(6);
+  it('should go to previous hit', waitForAsync(() => {
+    contentSearchNavigationService.update(6);
 
-      contentSearchNavigationService.currentHitCounter.subscribe((index) => {
-        expect(index).toBe(5);
-      });
+    contentSearchNavigationService.currentHitCounter.subscribe((index) => {
+      expect(index).toBe(5);
+    });
 
-      contentSearchNavigationService.goToPreviousHit();
-    })
-  );
+    contentSearchNavigationService.goToPreviousHit();
+  }));
 
-  it(
-    'should return -1 if canvasIndex is before first hit',
-    waitForAsync(() => {
-      contentSearchNavigationService.currentHitCounter.subscribe((hit) => {
-        expect(hit).toBe(-1);
-      });
-
-      contentSearchNavigationService.update(0);
-    })
-  );
-
-  it(
-    'should return 0 if canvasIndex is on first hit',
-    waitForAsync(() => {
-      contentSearchNavigationService.currentHitCounter.subscribe((hit) => {
-        expect(hit).toBe(0);
-      });
-
-      contentSearchNavigationService.update(1);
-    })
-  );
-
-  it(
-    'should return 5 if canvasIndex is between 5th and 6th hit',
-    waitForAsync(() => {
-      contentSearchNavigationService.currentHitCounter.subscribe((hit) => {
-        expect(hit).toBe(5);
-      });
-
-      contentSearchNavigationService.update(6);
-    })
-  );
-
-  it(
-    'should return 6 if canvasIndex is after last',
-    waitForAsync(() => {
-      contentSearchNavigationService.currentHitCounter.subscribe((hit) => {
-        expect(hit).toBe(6);
-      });
-
-      contentSearchNavigationService.update(10);
-    })
-  );
-
-  it('should reset currentHitCounter when searchresult is updated', waitForAsync(() => {
-    contentSearchNavigationService.update(12);
-
+  it('should return -1 if canvasIndex is before first hit', waitForAsync(() => {
     contentSearchNavigationService.currentHitCounter.subscribe((hit) => {
       expect(hit).toBe(-1);
     });
 
-    const updatedSearchResult = createSearchResult();
-    updatedSearchResult.add(new Hit({ id: 7, index: 10 }));
-    iiifContentSearchServiceStub._currentSearchResult.next(updatedSearchResult);
+    contentSearchNavigationService.update(0);
   }));
+
+  it('should return 0 if canvasIndex is on first hit', waitForAsync(() => {
+    contentSearchNavigationService.currentHitCounter.subscribe((hit) => {
+      expect(hit).toBe(0);
+    });
+
+    contentSearchNavigationService.update(1);
+  }));
+
+  it('should return 5 if canvasIndex is between 5th and 6th hit', waitForAsync(() => {
+    contentSearchNavigationService.currentHitCounter.subscribe((hit) => {
+      expect(hit).toBe(5);
+    });
+
+    contentSearchNavigationService.update(6);
+  }));
+
+  it('should return 6 if canvasIndex is after last', waitForAsync(() => {
+    contentSearchNavigationService.currentHitCounter.subscribe((hit) => {
+      expect(hit).toBe(6);
+    });
+
+    contentSearchNavigationService.update(10);
+  }));
+
+  it('should call update function when searchresult changes', () => {
+    spyOn(contentSearchNavigationService, 'update');
+
+    const updatedSearchResult = createSearchResult();
+    updatedSearchResult.add(new Hit({ id: 7, index: 20 }));
+    iiifContentSearchServiceStub._currentSearchResult.next(updatedSearchResult);
+
+    expect(contentSearchNavigationService.update).toHaveBeenCalledTimes(1);
+  });
 
   function createCanvasGroups(): Rect[] {
     const canvasGroups: Rect[] = [];

--- a/libs/ngx-mime/src/lib/core/navigation/content-search-navigation-service/content-search-navigation.service.spec.ts
+++ b/libs/ngx-mime/src/lib/core/navigation/content-search-navigation-service/content-search-navigation.service.spec.ts
@@ -111,9 +111,9 @@ describe('ContentSearchNavigationService', () => {
 
   it('should call update function when searchresult changes', () => {
     spyOn(contentSearchNavigationService, 'update');
-
     const updatedSearchResult = createSearchResult();
     updatedSearchResult.add(new Hit({ id: 7, index: 20 }));
+
     iiifContentSearchServiceStub._currentSearchResult.next(updatedSearchResult);
 
     expect(contentSearchNavigationService.update).toHaveBeenCalledTimes(1);

--- a/libs/ngx-mime/src/lib/core/navigation/content-search-navigation-service/content-search-navigation.service.ts
+++ b/libs/ngx-mime/src/lib/core/navigation/content-search-navigation-service/content-search-navigation.service.ts
@@ -30,7 +30,8 @@ export class ContentSearchNavigationService {
       this.iiifContentSearchService.onChange.subscribe(
         (result: SearchResult) => {
           this.searchResult = result;
-          this.resetCurrentHit();
+          this.currentHit = null;
+          this.update(this.canvasService.currentCanvasGroupIndex);
         }
       )
     );
@@ -91,11 +92,6 @@ export class ContentSearchNavigationService {
     } else {
       return this.lastHitIndex;
     }
-  }
-
-  private resetCurrentHit(): void {
-    this.currentHit = null;
-    this.update(0);
   }
 
   private goToNextCurrentCanvasHit() {

--- a/libs/ngx-mime/src/lib/core/navigation/content-search-navigation-service/content-search-navigation.service.ts
+++ b/libs/ngx-mime/src/lib/core/navigation/content-search-navigation-service/content-search-navigation.service.ts
@@ -31,6 +31,7 @@ export class ContentSearchNavigationService {
         (result: SearchResult) => {
           this.searchResult = result;
           this.currentHit = null;
+          this.update(0);
         }
       )
     );
@@ -157,7 +158,7 @@ export class ContentSearchNavigationService {
       return false;
     }
     return (
-      this.canvasesPerCanvasGroup.indexOf(
+      this.canvasesPerCanvasGroup?.indexOf(
         this.searchResult.get(this.currentIndex).index
       ) >= 0
     );
@@ -168,19 +169,21 @@ export class ContentSearchNavigationService {
       return -1;
     }
 
-    for (let i = 0; i < this.searchResult.size(); i++) {
-      const hit = this.searchResult.get(i);
-      if (canvasGroupIndexes.indexOf(hit.index) >= 0) {
-        return i;
-      }
-      if (hit.index >= canvasGroupIndexes[canvasGroupIndexes.length - 1]) {
-        if (i === 0) {
-          return -1;
-        } else {
-          const phit = this.searchResult.get(i - 1);
-          return this.searchResult.hits.findIndex(
-            (sr) => sr.index === phit.index
-          );
+    if (canvasGroupIndexes) {
+      for (let i = 0; i < this.searchResult.size(); i++) {
+        const hit = this.searchResult.get(i);
+        if (canvasGroupIndexes.indexOf(hit.index) >= 0) {
+          return i;
+        }
+        if (hit.index >= canvasGroupIndexes[canvasGroupIndexes.length - 1]) {
+          if (i === 0) {
+            return -1;
+          } else {
+            const phit = this.searchResult.get(i - 1);
+            return this.searchResult.hits.findIndex(
+              (sr) => sr.index === phit.index
+            );
+          }
         }
       }
     }
@@ -188,7 +191,7 @@ export class ContentSearchNavigationService {
   }
 
   private findLastHitIndex(canvasGroupIndexes: number[]): number {
-    if (!this.searchResult) {
+    if (!this.searchResult || !canvasGroupIndexes) {
       return -1;
     }
     const hits = this.searchResult.hits.filter(

--- a/libs/ngx-mime/src/lib/core/navigation/content-search-navigation-service/content-search-navigation.service.ts
+++ b/libs/ngx-mime/src/lib/core/navigation/content-search-navigation-service/content-search-navigation.service.ts
@@ -30,8 +30,7 @@ export class ContentSearchNavigationService {
       this.iiifContentSearchService.onChange.subscribe(
         (result: SearchResult) => {
           this.searchResult = result;
-          this.currentHit = null;
-          this.update(0);
+          this.resetCurrentHit();
         }
       )
     );
@@ -52,19 +51,6 @@ export class ContentSearchNavigationService {
 
   get currentHitCounter(): Observable<number> {
     return this._currentHitCounter$.pipe(distinctUntilChanged());
-  }
-
-  private updateCurrentHitCounter(): number {
-    if (this.isCurrentHitOnCurrentCanvasGroup()) {
-      if (this.currentHit) {
-        return this.currentHit.id;
-      }
-    }
-    if (this.isHitOnActiveCanvasGroup) {
-      return this.currentIndex;
-    } else {
-      return this.lastHitIndex;
-    }
   }
 
   getHitOnActiveCanvasGroup(): boolean {
@@ -92,6 +78,24 @@ export class ContentSearchNavigationService {
     this._currentHitCounter$.next(this.currentHit.id);
     this.currentIndex = this.currentHit.index;
     this.iiifContentSearchService.selected(hit);
+  }
+
+  private updateCurrentHitCounter(): number {
+    if (this.isCurrentHitOnCurrentCanvasGroup()) {
+      if (this.currentHit) {
+        return this.currentHit.id;
+      }
+    }
+    if (this.isHitOnActiveCanvasGroup) {
+      return this.currentIndex;
+    } else {
+      return this.lastHitIndex;
+    }
+  }
+
+  private resetCurrentHit(): void {
+    this.currentHit = null;
+    this.update(0);
   }
 
   private goToNextCurrentCanvasHit() {


### PR DESCRIPTION
- Calling update function when searchresult is changed to update currentHit correctly.
- Fixed a few checks for undefined values
- Added test

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When performing a new content search, the current hit in content search navigator does not update according to new searchresult. In some cases you can end up with the navigator displaying "6 of 3 hits", and navigation buttons not working.

Issue Number: N/A

## What is the new behavior?
currentHit is now reset when searchresult is updated.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
