### PR TITLE
fix: handle search hits/highlighting over two pages

### DIFF
--- a/libs/ngx-mime/src/lib/core/builders/iiif/search-result.builder.spec.ts
+++ b/libs/ngx-mime/src/lib/core/builders/iiif/search-result.builder.spec.ts
@@ -1,5 +1,9 @@
-import { a300dpiManifest, a400dpiManifest } from '../../../test/testManifest';
-import { testSearchResult } from '../../../test/testSearchResult';
+import {
+  a300dpiManifest,
+  a400dpiManifest,
+  searchHitsOverMultiplePagesManifest,
+} from '../../../test/testManifest';
+import { testSearchResult, testSearchResultOverMultiplePages } from '../../../test/testSearchResult';
 import { MimeViewerConfig } from '../../mime-viewer-config';
 import { IiifSearchResult } from '../../models/iiif-search-result';
 import { Manifest } from '../../models/manifest';
@@ -39,12 +43,12 @@ describe('SearchResultBuilder', () => {
     expect(searchResult.hits.length).toEqual(2);
     expect(searchResult.hits[0].index).toEqual(0);
     expect(searchResult.hits[0].label).toEqual('label1');
-    expect(searchResult.hits[0].rects[0].x).toEqual(304);
-    expect(searchResult.hits[0].rects[0].y).toEqual(1178);
-    expect(searchResult.hits[0].rects[0].width).toEqual(1024);
-    expect(searchResult.hits[0].rects[0].height).toEqual(137);
-    expect(searchResult.hits[0].rects[0].centerX).toEqual(816);
-    expect(searchResult.hits[0].rects[0].centerY).toEqual(1246.5);
+    expect(searchResult.hits[0].highlightRects[0].x).toEqual(304);
+    expect(searchResult.hits[0].highlightRects[0].y).toEqual(1178);
+    expect(searchResult.hits[0].highlightRects[0].width).toEqual(1024);
+    expect(searchResult.hits[0].highlightRects[0].height).toEqual(137);
+    expect(searchResult.hits[0].highlightRects[0].centerX).toEqual(816);
+    expect(searchResult.hits[0].highlightRects[0].centerY).toEqual(1246.5);
   });
 
   it('should return search result for 300 dpi manifest', () => {
@@ -60,11 +64,28 @@ describe('SearchResultBuilder', () => {
     expect(searchResult.hits.length).toEqual(2);
     expect(searchResult.hits[0].index).toEqual(0);
     expect(searchResult.hits[0].label).toEqual('label1');
-    expect(searchResult.hits[0].rects[0].x).toEqual(405);
-    expect(searchResult.hits[0].rects[0].y).toEqual(1570);
-    expect(searchResult.hits[0].rects[0].width).toEqual(1365);
-    expect(searchResult.hits[0].rects[0].height).toEqual(182);
-    expect(searchResult.hits[0].rects[0].centerX).toEqual(1087.5);
-    expect(searchResult.hits[0].rects[0].centerY).toEqual(1661);
+    expect(searchResult.hits[0].highlightRects[0].x).toEqual(405);
+    expect(searchResult.hits[0].highlightRects[0].y).toEqual(1570);
+    expect(searchResult.hits[0].highlightRects[0].width).toEqual(1365);
+    expect(searchResult.hits[0].highlightRects[0].height).toEqual(182);
+    expect(searchResult.hits[0].highlightRects[0].centerX).toEqual(1087.5);
+    expect(searchResult.hits[0].highlightRects[0].centerY).toEqual(1661);
+  });
+
+  it('should return search result with hits over multiple pages', () => {
+    const q = 'lastebilkøyraren';
+    const manifest = new ManifestBuilder(searchHitsOverMultiplePagesManifest).build();
+    const searchResult = new SearchResultBuilder(
+      q,
+      manifest,
+      testSearchResultOverMultiplePages,
+      config
+    ).build();
+
+    expect(searchResult.hits.length).toEqual(2);
+    expect(searchResult.hits[0].index).toEqual(0);
+    expect(searchResult.hits[0].highlightRects.length).toEqual(2);
+    expect(searchResult.hits[0].highlightRects[0].canvasIndex).toEqual(0);
+    expect(searchResult.hits[0].highlightRects[1].canvasIndex).toEqual(1);
   });
 });

--- a/libs/ngx-mime/src/lib/core/builders/iiif/search-result.builder.ts
+++ b/libs/ngx-mime/src/lib/core/builders/iiif/search-result.builder.ts
@@ -24,16 +24,17 @@ export class SearchResultBuilder {
     if (this.iiifSearchResult && this.iiifSearchResult.hits) {
       this.iiifSearchResult.hits.forEach((hit: IiifHit, index: number) => {
         const id: number = index;
-        let canvasIndex = -1;
+        let startCanvasIndex = -1;
         let label;
         const highlightRects: HighlightRect[] = [];
         if (this.manifest.sequences && this.manifest.sequences[0].canvases) {
           const resources = this.findResources(hit);
           resources.forEach((resource, index) => {
             if (index === 0) {
-              canvasIndex = this.findSequenceIndex(resource);
-              label = this.findLabel(canvasIndex);
+              startCanvasIndex = this.findSequenceIndex(resource);
+              label = this.findLabel(startCanvasIndex);
             }
+            const canvasIndex = this.findSequenceIndex(resource);
             const on = resource.on;
             if (on) {
               const scale = this.getScale(canvasIndex);
@@ -43,7 +44,7 @@ export class SearchResultBuilder {
                 y: this.scaleValue(coords[1], scale),
                 width: this.scaleValue(coords[2], scale),
                 height: this.scaleValue(coords[3], scale),
-                canvasIndex: this.findSequenceIndex(resource),
+                canvasIndex
               });
               highlightRects.push(rect);
             }
@@ -53,7 +54,7 @@ export class SearchResultBuilder {
         searchResult.add(
           new Hit({
             id: id,
-            index: canvasIndex,
+            index: startCanvasIndex,
             label: label,
             match: hit.match,
             before: hit.before,

--- a/libs/ngx-mime/src/lib/core/highlight-service/highlight.service.spec.ts
+++ b/libs/ngx-mime/src/lib/core/highlight-service/highlight.service.spec.ts
@@ -86,7 +86,7 @@ describe('HighlightService', () => {
       label: '',
       before: '',
       after: '',
-      rects: [],
+      highlightRects: [],
     };
   }
 });

--- a/libs/ngx-mime/src/lib/core/models/highlight-rect.ts
+++ b/libs/ngx-mime/src/lib/core/models/highlight-rect.ts
@@ -1,0 +1,24 @@
+import { Rect } from './rect';
+
+export class HighlightRect extends Rect {
+  public canvasIndex = 0;
+
+  constructor(fields?: {
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+    canvasIndex?: number;
+  }) {
+    super();
+    if (fields) {
+      this.x = fields.x || this.x;
+      this.y = fields.y || this.y;
+      this.width = fields.width || this.width;
+      this.height = fields.height || this.height;
+      this.centerX = this.x + this.width / 2;
+      this.centerY = this.y + this.height / 2;
+      this.canvasIndex = fields.canvasIndex || this.canvasIndex;
+    }
+  }
+}

--- a/libs/ngx-mime/src/lib/core/models/hit.ts
+++ b/libs/ngx-mime/src/lib/core/models/hit.ts
@@ -1,4 +1,4 @@
-import { Rect } from './rect';
+import { HighlightRect } from './highlight-rect';
 
 export class Hit {
   public id = 0;
@@ -7,7 +7,7 @@ export class Hit {
   public match = '';
   public before = '';
   public after = '';
-  public rects: Rect[] = [];
+  public highlightRects: HighlightRect[] = [];
 
   constructor(fields?: {
     id?: number;
@@ -16,7 +16,7 @@ export class Hit {
     match?: string;
     before?: string;
     after?: string;
-    rects?: Rect[];
+    highlightRects?: HighlightRect[];
   }) {
     if (fields) {
       this.id = fields.id || this.id;
@@ -25,7 +25,7 @@ export class Hit {
       this.match = fields.match || this.match;
       this.before = fields.before || this.before;
       this.after = fields.after || this.after;
-      this.rects = fields.rects || this.rects;
+      this.highlightRects = fields.highlightRects || this.highlightRects;
     }
   }
 }

--- a/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.ts
@@ -192,8 +192,8 @@ export class ViewerService {
       const rotation = this.rotation.getValue();
 
       for (const hit of searchResult.hits) {
-        for (const rect of hit.rects) {
-          const canvasRect = this.canvasService.getCanvasRect(hit.index);
+        for (const rect of hit.highlightRects) {
+          const canvasRect = this.canvasService.getCanvasRect(rect.canvasIndex);
           if (canvasRect) {
             const currentHitStrokeOffset = 8;
             let width = rect.width + currentHitStrokeOffset;

--- a/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/viewer.service.ts
@@ -192,41 +192,41 @@ export class ViewerService {
       const rotation = this.rotation.getValue();
 
       for (const hit of searchResult.hits) {
-        for (const rect of hit.highlightRects) {
-          const canvasRect = this.canvasService.getCanvasRect(rect.canvasIndex);
+        for (const highlightRect of hit.highlightRects) {
+          const canvasRect = this.canvasService.getCanvasRect(highlightRect.canvasIndex);
           if (canvasRect) {
             const currentHitStrokeOffset = 8;
-            let width = rect.width + currentHitStrokeOffset;
-            let height = rect.height + currentHitStrokeOffset;
+            let width = highlightRect.width + currentHitStrokeOffset;
+            let height = highlightRect.height + currentHitStrokeOffset;
             let x = canvasRect.x - currentHitStrokeOffset / 2;
             let y = canvasRect.y - currentHitStrokeOffset / 2;
 
             /* hit rect are relative to each unrotated page canvasRect so x,y must be adjusted by the remaining space */
             switch (rotation) {
               case 0:
-                x += rect.x;
-                y += rect.y;
+                x += highlightRect.x;
+                y += highlightRect.y;
                 break;
 
               case 90:
-                x += canvasRect.width - rect.y - rect.height;
-                y += rect.x;
+                x += canvasRect.width - highlightRect.y - highlightRect.height;
+                y += highlightRect.x;
                 /* Flip height & width */
-                width = rect.height + currentHitStrokeOffset;
-                height = rect.width + currentHitStrokeOffset;
+                width = highlightRect.height + currentHitStrokeOffset;
+                height = highlightRect.width + currentHitStrokeOffset;
                 break;
 
               case 180:
-                x += canvasRect.width - (rect.x + rect.width);
-                y += canvasRect.height - (rect.y + rect.height);
+                x += canvasRect.width - (highlightRect.x + highlightRect.width);
+                y += canvasRect.height - (highlightRect.y + highlightRect.height);
                 break;
 
               case 270:
-                x += rect.y;
-                y += canvasRect.height - rect.x - rect.width;
+                x += highlightRect.y;
+                y += canvasRect.height - highlightRect.x - highlightRect.width;
                 /* Flip height & width */
-                width = rect.height + currentHitStrokeOffset;
-                height = rect.width + currentHitStrokeOffset;
+                width = highlightRect.height + currentHitStrokeOffset;
+                height = highlightRect.width + currentHitStrokeOffset;
                 break;
             }
 

--- a/libs/ngx-mime/src/lib/test/testManifest.ts
+++ b/libs/ngx-mime/src/lib/test/testManifest.ts
@@ -6516,3 +6516,272 @@ export let a400dpiManifest: any = {
     },
   ],
 };
+
+export let searchHitsOverMultiplePagesManifest = {
+  '@context': 'http://iiif.io/api/presentation/2/context.json',
+  '@type': 'sc:Manifest',
+  '@id':
+    'https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/manifest?profile=nbdigital',
+  label: 'Den nye maskina og andre noveller',
+  metadata: [
+    {
+      label: 'Tilgang',
+      value: 'Tilgang for norske IP-adresser',
+    },
+    {
+      label: 'Tittel',
+      value:
+        '<a href="https://www.dev.nb.no/search?mediatype=bøker&title=%22Den%20nye%20maskina%20og%20andre%20noveller%22">Den nye maskina og andre noveller</a>',
+    },
+    {
+      label: 'Forfatter',
+      value:
+        '<a href="https://www.dev.nb.no/search?mediatype=bøker&name=%22Lie,%20Arvid%20Torgeir%22">Lie, Arvid Torgeir</a>',
+    },
+    {
+      label: 'Publisert',
+      value:
+        'no#:Gyldendal, <a href="https://www.dev.nb.no/search?mediatype=bøker&fromDate=19860101&toDate=19861231">1986</a>',
+    },
+    {
+      label: 'Emne',
+      value:
+        '<a href="https://www.dev.nb.no/search?mediatype=bøker&subject=%22skj%C3%B8nnlitteratur%22">skjønnlitteratur</a> | <a href="https://www.dev.nb.no/search?mediatype=bøker&subject=%22voksen%22">voksen</a>',
+    },
+    {
+      label: 'Andre opplysninger',
+      value:
+        'Elektronisk reproduksjon [Norge] Nasjonalbiblioteket Digital 2012-07-12\n',
+    },
+    {
+      label: 'Språk',
+      value:
+        '<a href="https://www.dev.nb.no/search?mediatype=bøker&languages=%22nno%22">Norsk (Nynorsk)</a>',
+    },
+    {
+      label: 'ISBN',
+      value: '8205169136',
+    },
+    {
+      label: 'Kilde for metadata',
+      value:
+        'nb.bibsys.no (<a title="Link til post i Oria" href="https://www.oria.no/?vid=NB&search=998621016114702202">998621016114702202</a>)',
+    },
+    {
+      label: 'Omfang',
+      value: '97 s. 22 cm',
+    },
+    {
+      label: 'Medietype',
+      value: 'Bøker',
+    },
+    {
+      label: 'Dewey',
+      value: '839.823',
+    },
+    {
+      label: 'UDC',
+      value: '839.6',
+    },
+    {
+      label: 'Varig lenke',
+      value:
+        '<a href="https://urn.nb.no/URN:NBN:no-nb_digibok_2012062906086" target="_blank">https://urn.nb.no/URN:NBN:no-nb_digibok_2012062906086</a>',
+    },
+    {
+      label: '',
+      value:
+        '<a href="https://www.nb.no/items/ac21c8b1011362c2191a96584affd83b?manifest=https://api.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/manifest" target="_blank"><img src="https://www.nb.no/content/uploads/2018/08/logo-iiif.png" alt="IIIF Drag-n-drop"></a>',
+    },
+  ],
+  license: 'https://www.nb.no/lisens/stromming',
+  attribution: 'Det er kun tillatt å strømme dette materialet til privat bruk.',
+  service: {
+    '@context': 'http://iiif.io/api/search/0/context.json',
+    '@id':
+      'https://api.dev.nb.no:443/catalog/v1/contentsearch/ac21c8b1011362c2191a96584affd83b/search',
+    profile: 'http://iiif.io/api/search/0/search',
+  },
+  thumbnail: {
+    '@id':
+      'https://www.nb.no/services/image/resolver/URN:NBN:no-nb_digibok_2012062906086_C1/full/0,200/0/native.jpg',
+    '@type': 'dctypes:Image',
+    format: 'image/jpeg',
+    service: {
+      '@context': 'http://iiif.io/api/image/2/context.json',
+      '@id':
+        'https://www.nb.no/services/image/resolver/URN:NBN:no-nb_digibok_2012062906086_C1',
+      protocol: 'http://iiif.io/api/image',
+      profile: 'http://iiif.io/api/image/2/level1.json',
+    },
+  },
+  sequences: [
+    {
+      '@id':
+        'https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/sequence/normal',
+      '@type': 'sc:Sequence',
+      label: 'Current Page Order',
+      viewingHint: 'paged',
+      rendering: [
+        {
+          '@id':
+            'https://www.nb.no/services/downloader?urn=URN:NBN:no-nb_digibok_2012062906086',
+          format: 'application/pdf',
+          label: 'Last ned som PDF',
+        },
+      ],
+      canvases: [
+        {
+          '@id':
+            'https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/canvas/URN:NBN:no-nb_digibok_2012062906086_0001',
+          '@type': 'sc:Canvas',
+          '@seeAlso': {
+            '@id':
+              'https://api.dev.nb.no:443/catalog/v1/metadata/ac21c8b1011362c2191a96584affd83b/altos/URN:NBN:no-nb_digibok_2012062906086_0001',
+            format: 'application/alto+xml',
+            profile: 'http://www.loc.gov/standards/alto',
+          },
+          label: '1',
+          height: 3193,
+          width: 1956,
+          images: [
+            {
+              '@id':
+                'https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/annotation/URN:NBN:no-nb_digibok_2012062906086_0001',
+              '@type': 'oa:Annotation',
+              motivation: 'sc:painting',
+              resource: {
+                '@id':
+                  'https://www.nb.no/services/image/resolver/URN:NBN:no-nb_digibok_2012062906086_0001/full/full/0/native.jpg',
+                '@type': 'dctypes:Image',
+                format: 'image/jpeg',
+                service: {
+                  '@context': 'http://iiif.io/api/image/2/context.json',
+                  '@id':
+                    'https://www.nb.no/services/image/resolver/URN:NBN:no-nb_digibok_2012062906086_0001',
+                  protocol: 'http://iiif.io/api/image',
+                  width: 1956,
+                  height: 3193,
+                  sizes: [
+                    {
+                      width: 978,
+                      height: 1596,
+                    },
+                    {
+                      width: 489,
+                      height: 798,
+                    },
+                    {
+                      width: 244,
+                      height: 399,
+                    },
+                    {
+                      width: 122,
+                      height: 199,
+                    },
+                    {
+                      width: 61,
+                      height: 99,
+                    },
+                  ],
+                  tiles: [
+                    {
+                      width: 1024,
+                      scaleFactors: [1, 2, 4, 8, 16, 32],
+                    },
+                  ],
+                  profile: 'http://iiif.io/api/image/2/level1.json',
+                  service: {
+                    '@context':
+                      'http://iiif.io/api/annex/services/physdim/1/context.json',
+                    profile: 'http://iiif.io/api/annex/services/physdim',
+                    physicalScale: 0.0025,
+                    physicalUnits: 'in',
+                  },
+                },
+                height: 3193,
+                width: 1956,
+              },
+              on: 'https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/canvas/URN:NBN:no-nb_digibok_2012062906086_0001',
+            },
+          ],
+        },
+        {
+          '@id':
+            'https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/canvas/URN:NBN:no-nb_digibok_2012062906086_0002',
+          '@type': 'sc:Canvas',
+          '@seeAlso': {
+            '@id':
+              'https://api.dev.nb.no:443/catalog/v1/metadata/ac21c8b1011362c2191a96584affd83b/altos/URN:NBN:no-nb_digibok_2012062906086_0002',
+            format: 'application/alto+xml',
+            profile: 'http://www.loc.gov/standards/alto',
+          },
+          label: '2',
+          height: 3193,
+          width: 1956,
+          images: [
+            {
+              '@id':
+                'https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/annotation/URN:NBN:no-nb_digibok_2012062906086_0002',
+              '@type': 'oa:Annotation',
+              motivation: 'sc:painting',
+              resource: {
+                '@id':
+                  'https://www.nb.no/services/image/resolver/URN:NBN:no-nb_digibok_2012062906086_0002/full/full/0/native.jpg',
+                '@type': 'dctypes:Image',
+                format: 'image/jpeg',
+                service: {
+                  '@context': 'http://iiif.io/api/image/2/context.json',
+                  '@id':
+                    'https://www.nb.no/services/image/resolver/URN:NBN:no-nb_digibok_2012062906086_0002',
+                  protocol: 'http://iiif.io/api/image',
+                  width: 1956,
+                  height: 3193,
+                  sizes: [
+                    {
+                      width: 978,
+                      height: 1596,
+                    },
+                    {
+                      width: 489,
+                      height: 798,
+                    },
+                    {
+                      width: 244,
+                      height: 399,
+                    },
+                    {
+                      width: 122,
+                      height: 199,
+                    },
+                    {
+                      width: 61,
+                      height: 99,
+                    },
+                  ],
+                  tiles: [
+                    {
+                      width: 1024,
+                      scaleFactors: [1, 2, 4, 8, 16, 32],
+                    },
+                  ],
+                  profile: 'http://iiif.io/api/image/2/level1.json',
+                  service: {
+                    '@context':
+                      'http://iiif.io/api/annex/services/physdim/1/context.json',
+                    profile: 'http://iiif.io/api/annex/services/physdim',
+                    physicalScale: 0.0025,
+                    physicalUnits: 'in',
+                  },
+                },
+                height: 3193,
+                width: 1956,
+              },
+              on: 'https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/canvas/URN:NBN:no-nb_digibok_2012062906086_0002',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/libs/ngx-mime/src/lib/test/testSearchResult.ts
+++ b/libs/ngx-mime/src/lib/test/testSearchResult.ts
@@ -54,3 +54,70 @@ export let testSearchResult: any = {
     },
   ],
 };
+
+export let testSearchResultOverMultiplePages: any = {
+  '@context': [
+    'http://iiif.io/api/presentation/2/context.json',
+    'http://iiif.io/api/search/0/context.json',
+  ],
+  '@id':
+    'https://api.dev.nb.no/catalog/v1/contentsearch/ac21c8b1011362c2191a96584affd83b/search?q=lastebilk%C3%B8yraren',
+  '@type': 'sc:AnnotationList',
+  resources: [
+    {
+      '@id':
+        'https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/annotation/URN:NBN:no-nb_digibok_2012062906086_0001#xywh=1406,2735,178,47',
+      '@type': 'oa:Annotation',
+      motivation: 'sc:painting',
+      resource: {
+        '@type': 'cnt:ContentAsText',
+        chars: 'lastebilkøyraren ',
+      },
+      on: 'https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/canvas/URN:NBN:no-nb_digibok_2012062906086_0001#xywh=1406,2735,178,47',
+    },
+    {
+      '@id':
+        'https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/annotation/URN:NBN:no-nb_digibok_2012062906086_0002#xywh=375,239,231,61',
+      '@type': 'oa:Annotation',
+      motivation: 'sc:painting',
+      resource: {
+        '@type': 'cnt:ContentAsText',
+        chars: 'lastebilkøyraren ',
+      },
+      on: 'https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/canvas/URN:NBN:no-nb_digibok_2012062906086_0002#xywh=375,239,231,61',
+    },
+    {
+      '@id':
+        'https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/annotation/URN:NBN:no-nb_digibok_2012062906086_0002#xywh=873,822,409,64',
+      '@type': 'oa:Annotation',
+      motivation: 'sc:painting',
+      resource: {
+        '@type': 'cnt:ContentAsText',
+        chars: 'lastebilkøyraren ',
+      },
+      on: 'https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/canvas/URN:NBN:no-nb_digibok_2012062906086_0002#xywh=873,822,409,64',
+    },
+  ],
+  hits: [
+    {
+      "@type": "search:Hit",
+      "annotations": [
+        "https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/annotation/URN:NBN:no-nb_digibok_2012062906086_0001#xywh=1406,2735,178,47",
+        "https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/annotation/URN:NBN:no-nb_digibok_2012062906086_0002#xywh=375,239,231,61"
+      ],
+      "match": "lastebilkøyraren ",
+      "before": "jern sette den tunge maskina seg i rørsle. - Ein liten tanke til denne kanten, ropa 14 ",
+      "after": " og gjorde på nytt eit teikn, men bare ein liten tanke! Olav Kås nikka, han hadde skjøna. "
+    },
+    {
+      "@type": "search:Hit",
+      "annotations": [
+        "https://api.dev.nb.no/catalog/v1/iiif/ac21c8b1011362c2191a96584affd83b/annotation/URN:NBN:no-nb_digibok_2012062906086_0002#xywh=873,822,409,64"
+      ],
+      "match": "lastebilkøyraren ",
+      "before": "på tverke og slo beltet mot lastekarmen og reiv han opp så flisane fauk. - Stans! skreik ",
+      "after": " og strekte båe armane i været og riste kraftig på hovudet mot Olav Kås og sette i "
+    }
+  ],
+};
+

--- a/libs/ngx-mime/src/lib/viewer/recognized-text-content/recognized-text-content.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/recognized-text-content/recognized-text-content.component.spec.ts
@@ -158,7 +158,7 @@ describe('RecognizedTextContentComponent', () => {
       label: '',
       before: '',
       after: '',
-      rects: [],
+      highlightRects: [],
     };
   }
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

If you have searchhits going over two pages it doesn't correctly highglight on both pages and just draw both rectangles on the last canvas

Issue Number: N/A

## What is the new behavior?

Now it correctly draws the rectangles on both canvases

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
