### PR TITLE
fix: can't override intl providers

### DIFF
--- a/libs/ngx-mime/src/lib/ngx-mime.module.ts
+++ b/libs/ngx-mime/src/lib/ngx-mime.module.ts
@@ -19,6 +19,7 @@ import { ViewerFooterComponent } from './viewer/viewer-footer/viewer-footer.comp
 import { ViewerHeaderComponent } from './viewer/viewer-header/viewer-header.component';
 import { ViewerSpinnerComponent } from './viewer/viewer-spinner/viewer-spinner.component';
 import { ViewerComponent } from './viewer/viewer.component';
+import { MimeViewerIntl } from './core/intl';
 
 @NgModule({
   declarations: [
@@ -41,6 +42,7 @@ import { ViewerComponent } from './viewer/viewer.component';
     ViewerSpinnerComponent,
   ],
   imports: [SharedModule],
+  providers: [MimeViewerIntl],
   exports: [ViewerComponent],
 })
 export class MimeModule {}

--- a/libs/ngx-mime/src/lib/viewer/viewer.providers.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer.providers.ts
@@ -11,7 +11,6 @@ import { FullscreenService } from '../core/fullscreen-service/fullscreen.service
 import { HighlightService } from '../core/highlight-service/highlight.service';
 import { IiifContentSearchService } from '../core/iiif-content-search-service/iiif-content-search.service';
 import { IiifManifestService } from '../core/iiif-manifest-service/iiif-manifest-service';
-import { MimeViewerIntl } from '../core/intl';
 import { MimeDomHelper } from '../core/mime-dom-helper';
 import { MimeResizeService } from '../core/mime-resize-service/mime-resize.service';
 import { ModeService } from '../core/mode-service/mode.service';
@@ -48,7 +47,6 @@ export const VIEWER_PROVIDERS = [
   InformationDialogService,
   MimeDomHelper,
   MimeResizeService,
-  MimeViewerIntl,
   ModeService,
   SpinnerService,
   StyleService,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

It is not possible to change Intl provider

Issue Number: N/A

## What is the new behavior?
Intl provider can be overridden from outside of the module

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
