### PR TITLE
fix: update hit status when searchResult changes

### DIFF
--- a/libs/ngx-mime/src/lib/viewer/viewer-footer/content-search-navigator/content-search-navigator.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer-footer/content-search-navigator/content-search-navigator.component.ts
@@ -3,8 +3,10 @@ import {
   ChangeDetectorRef,
   Component,
   Input,
+  OnChanges,
   OnDestroy,
   OnInit,
+  SimpleChanges,
 } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { CanvasService } from '../../../core/canvas-service/canvas-service';
@@ -22,7 +24,9 @@ import { ContentSearchNavigationService } from '../../../core/navigation/content
   styleUrls: ['./content-search-navigator.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ContentSearchNavigatorComponent implements OnInit, OnDestroy {
+export class ContentSearchNavigatorComponent
+  implements OnInit, OnDestroy, OnChanges
+{
   @Input() searchResult!: SearchResult;
   isHitOnActiveCanvasGroup = false;
   isFirstHit = false;
@@ -30,7 +34,6 @@ export class ContentSearchNavigatorComponent implements OnInit, OnDestroy {
   currentHit = 0;
   invert = false;
   private subscriptions = new Subscription();
-
 
   constructor(
     public intl: MimeViewerIntl,
@@ -45,9 +48,8 @@ export class ContentSearchNavigatorComponent implements OnInit, OnDestroy {
     this.contentSearchNavigationService.initialize();
     this.subscriptions.add(
       this.contentSearchNavigationService.currentHitCounter.subscribe((n) => {
-        this.isFirstHit = n <= 0;
-        this.isLastHit = n === this.searchResult.size() - 1;
         this.currentHit = n;
+        this.updateHitStatus();
       })
     );
     this.subscriptions.add(
@@ -77,6 +79,10 @@ export class ContentSearchNavigatorComponent implements OnInit, OnDestroy {
     );
   }
 
+  ngOnChanges(changes: SimpleChanges) {
+    this.updateHitStatus();
+  }
+
   ngOnDestroy() {
     this.subscriptions.unsubscribe();
     this.contentSearchNavigationService.destroy();
@@ -92,5 +98,10 @@ export class ContentSearchNavigatorComponent implements OnInit, OnDestroy {
 
   goToPreviousHit() {
     this.contentSearchNavigationService.goToPreviousHit();
+  }
+
+  private updateHitStatus() {
+    this.isFirstHit = this.currentHit <= 0;
+    this.isLastHit = this.currentHit === this.searchResult.size() - 1;
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Hit status is not updated when a new content search is executed

## What is the new behavior?
isFirstHit and isLastHit in ContentSearchNavigatorComponent is updated when serachResult input is changed

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
