### PR TITLE
fix: handle ResizeObserver not supported

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ jobs:
     steps:
       - checkout
       - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
       - run: 'mkdir -p $LOGS_DIR'
       - run: 'chmod +x ./scripts/ci/build-and-test.sh'
       - run: 'chmod +x ./scripts/lambdatest/start-tunnel.sh'

--- a/libs/ngx-mime/src/lib/core/mime-resize-service/mime-resize.service.ts
+++ b/libs/ngx-mime/src/lib/core/mime-resize-service/mime-resize.service.ts
@@ -36,22 +36,36 @@ export class MimeResizeService {
   }
 
   initialize() {
-    this.observer = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        this.resizeSubject.next(entry.contentRect);
-      }
-    });
-
-    const el: Element = this.el.nativeElement.querySelector(
-      `#${this.viewerService.id}`
-    );
-
-    this.observer.observe(el);
+    if (this.isResizeObserverSupported()) {
+      this.initializeResizeObserver();
+    }
   }
 
   destroy() {
-    if (this.observer) {
-      this.observer.disconnect();
+    this.observer?.disconnect();
+  }
+
+  private isResizeObserverSupported(): boolean {
+    return 'ResizeObserver' in window;
+  }
+
+  private initializeResizeObserver(): void {
+    this.observer = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+      for (const entry of entries) {
+        this.handleResizeEntry(entry);
+      }
+    });
+
+    const el: Element | null = this.el.nativeElement.querySelector(
+      `#${this.viewerService.id}`
+    );
+
+    if (el) {
+      this.observer?.observe(el);
     }
+  }
+
+  private handleResizeEntry(entry: ResizeObserverEntry): void {
+    this.resizeSubject.next(entry.contentRect);
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
ResizeObserver is not supported on some old devices (ref: https://caniuse.com/resizeobserver). 

Viewer throws Error `Can't find variable: ResizeObserver`

## What is the new behavior?
Resizing will be ignored on devices that do not support ResizeObserver

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
