### PR TITLE
feat: new layout and behavior for OSD toolbar

### DIFF
--- a/apps/integration-e2e/src/pages/viewer.po.ts
+++ b/apps/integration-e2e/src/pages/viewer.po.ts
@@ -505,16 +505,24 @@ export class ViewerPage {
     //   });
   }
 
+  async openOsdControls(): Promise<void> {
+    const buttonText = await this.page.getByTestId('fabButton').innerText();
+    if (buttonText === 'menu') {
+      await this.clickButtonByTestId('fabButton');
+      await this.animations.waitFor();
+    }
+  }
+
   async clickZoomInButton(): Promise<void> {
-    await this.clickNavigationButton('zoomInButton');
+    await this.clickButtonByTestId('zoomInButton');
   }
 
   async clickZoomOutButton(): Promise<void> {
-    await this.clickNavigationButton('zoomOutButton');
+    await this.clickButtonByTestId('zoomOutButton');
   }
 
   async clickZoomHomeButton(): Promise<void> {
-    await this.clickNavigationButton('homeButton');
+    await this.clickButtonByTestId('homeButton');
   }
 
   async clickNextButton(): Promise<void> {
@@ -527,11 +535,12 @@ export class ViewerPage {
     await this.animations.waitFor(500);
   }
 
-  async clickNavigationButton(buttonId: string): Promise<void> {
-    await this.page.getByTestId(buttonId).click();
+  async clickButtonByTestId(testId: string): Promise<void> {
+    await this.page.getByTestId(testId).click();
   }
 
   async clickDisableableNavigationButton(buttonId: string): Promise<void> {
+    await this.openOsdControls();
     const button: Locator = this.page.getByTestId(buttonId);
 
     if (await button.isEnabled()) {

--- a/apps/integration-e2e/src/step-definitions/zoom.steps.ts
+++ b/apps/integration-e2e/src/step-definitions/zoom.steps.ts
@@ -16,6 +16,7 @@ Given('the view is all zoomed out', async function (this: CustomWorld) {
 });
 
 Given('the view is zoomed in', async function (this: CustomWorld) {
+  await this.viewerPage.openOsdControls();
   await this.viewerPage.clickZoomInButton();
   await this.animations.waitFor();
   previousZoomLevel = await this.viewerPage.getZoomLevel();
@@ -35,12 +36,14 @@ When('the user pinch in', async function (this: CustomWorld) {
 
 When('the user click zoom in button', async function (this: CustomWorld) {
   previousZoomLevel = await this.viewerPage.getZoomLevel();
+  await this.viewerPage.openOsdControls();
   await this.viewerPage.clickZoomInButton();
   await this.animations.waitFor();
 });
 
 When('the user click zoom out button', async function (this: CustomWorld) {
   previousZoomLevel = await this.viewerPage.getZoomLevel();
+  await this.viewerPage.openOsdControls();
   await this.viewerPage.clickZoomOutButton();
   await this.animations.waitFor();
 });

--- a/libs/ngx-mime/ngx-mime.theme.scss
+++ b/libs/ngx-mime/ngx-mime.theme.scss
@@ -1,7 +1,9 @@
 @import 'src/lib/information-dialog/metadata/metadata.component.theme.scss';
 @import 'src/lib/information-dialog/table-of-contents/table-of-contents.component.theme.scss';
+@import 'src/lib/viewer/osd-toolbar/osd-toolbar.component.theme';
 
 @mixin ngx-mime-theme($test-app-theme) {
   @include metadata-component-theme($test-app-theme);
   @include table-of-contents-theme($test-app-theme);
+  @include osd-toolbar-component-theme($test-app-theme);
 }

--- a/libs/ngx-mime/src/lib/core/intl/viewer-intl.lt.ts
+++ b/libs/ngx-mime/src/lib/core/intl/viewer-intl.lt.ts
@@ -23,11 +23,12 @@ export class MimeViewerIntlLt extends MimeViewerIntl {
   override tocLabel = 'Turinys';
   override fullScreenLabel = 'Pilno ekrano režimas';
   override exitFullScreenLabel = 'Išeiti iš pilno ekrano režimo';
+  override osdControlsAriaLabel = 'Kontrolės skydelis';
   override zoomInLabel = 'Priartinti';
   override zoomOutLabel = 'Atitolinti';
+  override zoomHomeLabel = 'Padidinti puslapį';
   override previousPageLabel = 'Buvęs puslapis';
   override nextPageLabel = 'Kitas puslapis';
-  override homeLabel = 'Grįžti į pradžią';
   override rotateCwLabel = 'Pasukti 90°';
   override searchLabel = 'Paieška';
   override clearSearchLabel = 'Išvalyti';

--- a/libs/ngx-mime/src/lib/core/intl/viewer-intl.lt.ts
+++ b/libs/ngx-mime/src/lib/core/intl/viewer-intl.lt.ts
@@ -23,8 +23,8 @@ export class MimeViewerIntlLt extends MimeViewerIntl {
   override tocLabel = 'Turinys';
   override fullScreenLabel = 'Pilno ekrano režimas';
   override exitFullScreenLabel = 'Išeiti iš pilno ekrano režimo';
-  override openOsdControlPanelAriaLabel = 'Atidarykite valdymo skydelį';
-  override closeOsdControlPanelAriaLabel = 'Uždarykite valdymo skydelį';
+  override openOsdControlPanelLabel = 'Atidarykite valdymo skydelį';
+  override closeOsdControlPanelLabel = 'Uždarykite valdymo skydelį';
   override zoomInLabel = 'Priartinti';
   override zoomOutLabel = 'Atitolinti';
   override resetZoomLabel = 'iš naujo nustatykite skalę';

--- a/libs/ngx-mime/src/lib/core/intl/viewer-intl.lt.ts
+++ b/libs/ngx-mime/src/lib/core/intl/viewer-intl.lt.ts
@@ -23,10 +23,11 @@ export class MimeViewerIntlLt extends MimeViewerIntl {
   override tocLabel = 'Turinys';
   override fullScreenLabel = 'Pilno ekrano režimas';
   override exitFullScreenLabel = 'Išeiti iš pilno ekrano režimo';
-  override osdControlsAriaLabel = 'Kontrolės skydelis';
+  override openOsdControlPanelAriaLabel = 'Atidarykite valdymo skydelį';
+  override closeOsdControlPanelAriaLabel = 'Uždarykite valdymo skydelį';
   override zoomInLabel = 'Priartinti';
   override zoomOutLabel = 'Atitolinti';
-  override zoomHomeLabel = 'Padidinti puslapį';
+  override resetZoomLabel = 'iš naujo nustatykite skalę';
   override previousPageLabel = 'Buvęs puslapis';
   override nextPageLabel = 'Kitas puslapis';
   override rotateCwLabel = 'Pasukti 90°';

--- a/libs/ngx-mime/src/lib/core/intl/viewer-intl.no_nb.ts
+++ b/libs/ngx-mime/src/lib/core/intl/viewer-intl.no_nb.ts
@@ -23,10 +23,11 @@ export class MimeViewerIntlNoNb extends MimeViewerIntl {
   override tocLabel = 'Innholdsfortegnelse';
   override fullScreenLabel = 'Fullskjerm';
   override exitFullScreenLabel = 'Avslutt fullskjerm';
-  override osdControlsAriaLabel = 'Kontrollpanel';
+  override openOsdControlPanelAriaLabel = 'Åpne kontrollpanel';
+  override closeOsdControlPanelAriaLabel = 'Lukk kontrollpanel';
   override zoomInLabel = 'Zoom inn';
   override zoomOutLabel = 'Zoom ut';
-  override zoomHomeLabel = 'Zoom til sidestørrelse';
+  override resetZoomLabel = 'Nullstill zoom';
   override previousPageLabel = 'Forrige side';
   override nextPageLabel = 'Neste side';
   override rotateCwLabel = 'Rotér 90°';

--- a/libs/ngx-mime/src/lib/core/intl/viewer-intl.no_nb.ts
+++ b/libs/ngx-mime/src/lib/core/intl/viewer-intl.no_nb.ts
@@ -23,11 +23,12 @@ export class MimeViewerIntlNoNb extends MimeViewerIntl {
   override tocLabel = 'Innholdsfortegnelse';
   override fullScreenLabel = 'Fullskjerm';
   override exitFullScreenLabel = 'Avslutt fullskjerm';
+  override osdControlsAriaLabel = 'Kontrollpanel';
   override zoomInLabel = 'Zoom inn';
   override zoomOutLabel = 'Zoom ut';
+  override zoomHomeLabel = 'Zoom til sidestørrelse';
   override previousPageLabel = 'Forrige side';
   override nextPageLabel = 'Neste side';
-  override homeLabel = 'Hjem';
   override rotateCwLabel = 'Rotér 90°';
   override searchLabel = 'Søk';
   override clearSearchLabel = 'Tøm';

--- a/libs/ngx-mime/src/lib/core/intl/viewer-intl.no_nb.ts
+++ b/libs/ngx-mime/src/lib/core/intl/viewer-intl.no_nb.ts
@@ -23,8 +23,8 @@ export class MimeViewerIntlNoNb extends MimeViewerIntl {
   override tocLabel = 'Innholdsfortegnelse';
   override fullScreenLabel = 'Fullskjerm';
   override exitFullScreenLabel = 'Avslutt fullskjerm';
-  override openOsdControlPanelAriaLabel = 'Åpne kontrollpanel';
-  override closeOsdControlPanelAriaLabel = 'Lukk kontrollpanel';
+  override openOsdControlPanelLabel = 'Åpne kontrollpanel';
+  override closeOsdControlPanelLabel = 'Lukk kontrollpanel';
   override zoomInLabel = 'Zoom inn';
   override zoomOutLabel = 'Zoom ut';
   override resetZoomLabel = 'Nullstill zoom';

--- a/libs/ngx-mime/src/lib/core/intl/viewer-intl.no_nb.ts
+++ b/libs/ngx-mime/src/lib/core/intl/viewer-intl.no_nb.ts
@@ -46,7 +46,8 @@ export class MimeViewerIntlNoNb extends MimeViewerIntl {
   override manifestUriMissingLabel = 'Lenke til manifest mangler';
   override manifestNotValidLabel = 'Manifestet er ikke gyldig';
   override pageDoesNotExists = 'Beklager, men den siden finnes ikke';
-  override textContentErrorLabel = 'Beklager, men jeg finner ikke teksten for deg';
+  override textContentErrorLabel =
+    'Beklager, men jeg finner ikke teksten for deg';
 
   override noResultsFoundLabel = (q: string) => {
     return `Ingen treff funnet for <em class="current-search">${q}</em>`;

--- a/libs/ngx-mime/src/lib/core/intl/viewer-intl.ts
+++ b/libs/ngx-mime/src/lib/core/intl/viewer-intl.ts
@@ -29,7 +29,7 @@ export class MimeViewerIntl {
   zoomOutLabel = 'Zoom out';
   previousPageLabel = 'Previous Page';
   nextPageLabel = 'Next Page';
-  homeLabel = 'Go Home';
+  homeLabel = 'Zoom Home';
   rotateCwLabel = 'Rotate 90°';
   searchLabel = 'Search';
   clearSearchLabel = 'Clear';

--- a/libs/ngx-mime/src/lib/core/intl/viewer-intl.ts
+++ b/libs/ngx-mime/src/lib/core/intl/viewer-intl.ts
@@ -25,11 +25,12 @@ export class MimeViewerIntl {
   tocLabel = 'Table of Contents';
   fullScreenLabel = 'Full screen';
   exitFullScreenLabel = 'Exit full screen';
+  osdControlsAriaLabel = 'OSD controls';
   zoomInLabel = 'Zoom in';
   zoomOutLabel = 'Zoom out';
+  zoomHomeLabel = 'Zoom to page';
   previousPageLabel = 'Previous Page';
   nextPageLabel = 'Next Page';
-  homeLabel = 'Zoom Home';
   rotateCwLabel = 'Rotate 90°';
   searchLabel = 'Search';
   clearSearchLabel = 'Clear';

--- a/libs/ngx-mime/src/lib/core/intl/viewer-intl.ts
+++ b/libs/ngx-mime/src/lib/core/intl/viewer-intl.ts
@@ -25,10 +25,11 @@ export class MimeViewerIntl {
   tocLabel = 'Table of Contents';
   fullScreenLabel = 'Full screen';
   exitFullScreenLabel = 'Exit full screen';
-  osdControlsAriaLabel = 'OSD controls';
+  openOsdControlPanelAriaLabel = 'Open control panel';
+  closeOsdControlPanelAriaLabel = 'Close control panel';
   zoomInLabel = 'Zoom in';
   zoomOutLabel = 'Zoom out';
-  zoomHomeLabel = 'Zoom to page';
+  resetZoomLabel = 'Reset zoom';
   previousPageLabel = 'Previous Page';
   nextPageLabel = 'Next Page';
   rotateCwLabel = 'Rotate 90°';

--- a/libs/ngx-mime/src/lib/core/intl/viewer-intl.ts
+++ b/libs/ngx-mime/src/lib/core/intl/viewer-intl.ts
@@ -25,8 +25,8 @@ export class MimeViewerIntl {
   tocLabel = 'Table of Contents';
   fullScreenLabel = 'Full screen';
   exitFullScreenLabel = 'Exit full screen';
-  openOsdControlPanelAriaLabel = 'Open control panel';
-  closeOsdControlPanelAriaLabel = 'Close control panel';
+  openOsdControlPanelLabel = 'Open control panel';
+  closeOsdControlPanelLabel = 'Close control panel';
   zoomInLabel = 'Zoom in';
   zoomOutLabel = 'Zoom out';
   resetZoomLabel = 'Reset zoom';

--- a/libs/ngx-mime/src/lib/shared/animations.ts
+++ b/libs/ngx-mime/src/lib/shared/animations.ts
@@ -5,7 +5,7 @@ import {
   transition,
   trigger,
 } from '@angular/animations';
-import { ViewerOptions } from './../../core/models/viewer-options';
+import { ViewerOptions } from './../core/models/viewer-options';
 
 export const slideInLeft = trigger('slideInLeft', [
   state(

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/animations.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/animations.ts
@@ -1,0 +1,54 @@
+import {
+  animate,
+  state,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
+import { ViewerOptions } from './../../core/models/viewer-options';
+
+export const slideInLeft = trigger('osdComponentState', [
+  state(
+    'hide',
+    style({
+      transform: 'translate(-100%, 0)',
+      display: 'none',
+    })
+  ),
+  state(
+    'show',
+    style({
+      transform: 'translate(0px, 0px)',
+      display: 'block',
+    })
+  ),
+  transition(
+    'hide => show',
+    animate(`${ViewerOptions.transitions.toolbarsEaseInTime}ms ease-out`)
+  ),
+  transition(
+    'show => hide',
+    animate(`${ViewerOptions.transitions.toolbarsEaseOutTime}ms ease-in`)
+  ),
+]);
+
+export const rotate45 = trigger('fabOpenState', [
+  transition('closed => open', [
+    style({ transform: 'rotate(-45deg)', opacity: 0 }),
+    animate(`100ms`),
+  ]),
+  transition('open => closed', [
+    style({ transform: 'rotate(45deg)', opacity: 0 }),
+    animate(`100ms`),
+  ]),
+]);
+
+export const easeInWithDelay = trigger('OsdControlsState', [
+  state('void', style({ transform: 'scale(0)' })),
+  transition(':enter', animate(`1ms {{delayEnter}}ms ease-out`), {
+    params: { delayEnter: 0 },
+  }),
+  transition(':leave', animate(`1ms {{delayLeave}}ms ease-in`), {
+    params: { delayLeave: 0 },
+  }),
+]);

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/animations.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/animations.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular/animations';
 import { ViewerOptions } from './../../core/models/viewer-options';
 
-export const slideInLeft = trigger('osdComponentState', [
+export const slideInLeft = trigger('slideInLeft', [
   state(
     'hide',
     style({
@@ -32,7 +32,7 @@ export const slideInLeft = trigger('osdComponentState', [
   ),
 ]);
 
-export const rotate45 = trigger('fabOpenState', [
+export const rotate45 = trigger('rotate45', [
   transition('closed => open', [
     style({ transform: 'rotate(-45deg)', opacity: 0 }),
     animate(`100ms`),
@@ -43,7 +43,7 @@ export const rotate45 = trigger('fabOpenState', [
   ]),
 ]);
 
-export const easeInWithDelay = trigger('OsdControlsState', [
+export const easeInWithDelay = trigger('easeInWithDelay', [
   state('void', style({ transform: 'scale(0)' })),
   transition(':enter', animate(`1ms {{delayEnter}}ms ease-out`), {
     params: { delayEnter: 0 },

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
@@ -1,8 +1,8 @@
 <div #container class="osd-toolbar">
   <div *ngIf="isWeb" class="flex gap-2">
     <div class="flex flex-col gap-2">
-      <button mat-fab (click)="onFabClick()">
-        <mat-icon [@fabOpenState]="fabOpenState">{{ fabOpenState }}</mat-icon>
+      <button mat-fab (click)="onFabClick()" data-testid="fabButton">
+        <mat-icon [@fabOpenState]="fabState">{{ fabIcon }}</mat-icon>
       </button>
     </div>
     <div class="flex items-center gap-2">

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
@@ -1,94 +1,89 @@
 <div #container class="osd-toolbar" [ngStyle]="osdToolbarStyle">
   <div *ngIf="isWeb" class="osd-toolbar-container flex-col">
-    <div class="osd-toolbar-row">
-      <ng-container *ngIf="invert">
-        <button
-          data-testid="navigateBeforeButton"
-          mat-icon-button
-          [attr.aria-label]="intl.previousPageLabel"
-          [matTooltip]="intl.previousPageLabel"
-          [disabled]="isFirstCanvasGroup"
-          (click)="goToPreviousCanvasGroup()"
-        >
-          <mat-icon>navigate_before</mat-icon>
-        </button>
-      </ng-container>
-      <ng-container *ngIf="!invert">
-        <button
-          data-testid="navigateNextButton"
-          mat-icon-button
-          [attr.aria-label]="intl.nextPageLabel"
-          [matTooltip]="intl.nextPageLabel"
-          [disabled]="isLastCanvasGroup"
-          (click)="goToNextCanvasGroup()"
-        >
-          <mat-icon>navigate_before</mat-icon>
-        </button>
-      </ng-container>
+    <ng-container *ngIf="invert">
       <button
-        (click)="home()"
-        data-testid="homeButton"
+        data-testid="navigateBeforeButton"
         mat-icon-button
-        [attr.aria-label]="intl.homeLabel"
-        [matTooltip]="intl.homeLabel"
+        [attr.aria-label]="intl.previousPageLabel"
+        [matTooltip]="intl.previousPageLabel"
+        [disabled]="isFirstCanvasGroup"
+        (click)="goToPreviousCanvasGroup()"
       >
-        <mat-icon>home</mat-icon>
+        <mat-icon>navigate_before</mat-icon>
       </button>
-      <ng-container *ngIf="invert">
-        <button
-          data-testid="navigateNextButton"
-          mat-icon-button
-          [attr.aria-label]="intl.nextPageLabel"
-          [matTooltip]="intl.nextPageLabel"
-          [disabled]="isLastCanvasGroup"
-          (click)="goToNextCanvasGroup()"
-        >
-          <mat-icon>navigate_next</mat-icon>
-        </button>
-      </ng-container>
-      <ng-container *ngIf="!invert">
-        <button
-          data-testid="navigateBeforeButton"
-          mat-icon-button
-          [attr.aria-label]="intl.previousPageLabel"
-          [matTooltip]="intl.previousPageLabel"
-          [disabled]="isFirstCanvasGroup"
-          (click)="goToPreviousCanvasGroup()"
-        >
-          <mat-icon>navigate_next</mat-icon>
-        </button>
-      </ng-container>
-    </div>
+    </ng-container>
+    <ng-container *ngIf="!invert">
+      <button
+        data-testid="navigateNextButton"
+        mat-icon-button
+        [attr.aria-label]="intl.nextPageLabel"
+        [matTooltip]="intl.nextPageLabel"
+        [disabled]="isLastCanvasGroup"
+        (click)="goToNextCanvasGroup()"
+      >
+        <mat-icon>navigate_before</mat-icon>
+      </button>
+    </ng-container>
+    <button
+      (click)="home()"
+      data-testid="homeButton"
+      mat-icon-button
+      [attr.aria-label]="intl.homeLabel"
+      [matTooltip]="intl.homeLabel"
+    >
+      <mat-icon>home</mat-icon>
+    </button>
+    <ng-container *ngIf="invert">
+      <button
+        data-testid="navigateNextButton"
+        mat-icon-button
+        [attr.aria-label]="intl.nextPageLabel"
+        [matTooltip]="intl.nextPageLabel"
+        [disabled]="isLastCanvasGroup"
+        (click)="goToNextCanvasGroup()"
+      >
+        <mat-icon>navigate_next</mat-icon>
+      </button>
+    </ng-container>
+    <ng-container *ngIf="!invert">
+      <button
+        data-testid="navigateBeforeButton"
+        mat-icon-button
+        [attr.aria-label]="intl.previousPageLabel"
+        [matTooltip]="intl.previousPageLabel"
+        [disabled]="isFirstCanvasGroup"
+        (click)="goToPreviousCanvasGroup()"
+      >
+        <mat-icon>navigate_next</mat-icon>
+      </button>
+    </ng-container>
+    <button
+      (click)="zoomIn()"
+      data-testid="zoomInButton"
+      mat-icon-button
+      [attr.aria-label]="intl.zoomInLabel"
+      [matTooltip]="intl.zoomInLabel"
+    >
+      <mat-icon>zoom_in</mat-icon>
+    </button>
 
-    <div class="osd-toolbar-row">
-      <button
-        (click)="zoomIn()"
-        data-testid="zoomInButton"
-        mat-icon-button
-        [attr.aria-label]="intl.zoomInLabel"
-        [matTooltip]="intl.zoomInLabel"
-      >
-        <mat-icon>zoom_in</mat-icon>
-      </button>
-
-      <button
-        (click)="rotate()"
-        data-testid="rotateButton"
-        mat-icon-button
-        [attr.aria-label]="intl.rotateCwLabel"
-        [matTooltip]="intl.rotateCwLabel"
-      >
-        <mat-icon>rotate_right</mat-icon>
-      </button>
-      <button
-        (click)="zoomOut()"
-        data-testid="zoomOutButton"
-        mat-icon-button
-        [attr.aria-label]="intl.zoomOutLabel"
-        [matTooltip]="intl.zoomOutLabel"
-      >
-        <mat-icon>zoom_out</mat-icon>
-      </button>
-    </div>
+    <button
+      (click)="rotate()"
+      data-testid="rotateButton"
+      mat-icon-button
+      [attr.aria-label]="intl.rotateCwLabel"
+      [matTooltip]="intl.rotateCwLabel"
+    >
+      <mat-icon>rotate_right</mat-icon>
+    </button>
+    <button
+      (click)="zoomOut()"
+      data-testid="zoomOutButton"
+      mat-icon-button
+      [attr.aria-label]="intl.zoomOutLabel"
+      [matTooltip]="intl.zoomOutLabel"
+    >
+      <mat-icon>zoom_out</mat-icon>
+    </button>
   </div>
 </div>

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
@@ -6,7 +6,16 @@
         aria-controls="osdControls"
         data-testid="fabButton"
         [attr.aria-expanded]="fabState === 'open'"
-        [attr.aria-label]="intl.osdControlsAriaLabel"
+        [attr.aria-label]="
+          fabState === 'open'
+            ? intl.closeOsdControlPanelAriaLabel
+            : intl.openOsdControlPanelAriaLabel
+        "
+        [matTooltip]="
+          fabState === 'open'
+            ? intl.closeOsdControlPanelAriaLabel
+            : intl.openOsdControlPanelAriaLabel
+        "
         (click)="toggleFab()"
       >
         <mat-icon [@rotate45]="fabState">{{ fabIcon }}</mat-icon>
@@ -109,9 +118,9 @@
         (click)="home()"
         data-testid="homeButton"
         mat-mini-fab
-        [attr.aria-label]="intl.zoomHomeLabel"
+        [attr.aria-label]="intl.resetZoomLabel"
         [disabled]="!isZoomed"
-        [matTooltip]="intl.zoomHomeLabel"
+        [matTooltip]="intl.resetZoomLabel"
         [@easeInWithDelay]="{
           value: '',
           params: {

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
@@ -8,13 +8,13 @@
         [attr.aria-expanded]="fabState === 'open'"
         [attr.aria-label]="
           fabState === 'open'
-            ? intl.closeOsdControlPanelAriaLabel
-            : intl.openOsdControlPanelAriaLabel
+            ? intl.closeOsdControlPanelLabel
+            : intl.openOsdControlPanelLabel
         "
         [matTooltip]="
           fabState === 'open'
-            ? intl.closeOsdControlPanelAriaLabel
-            : intl.openOsdControlPanelAriaLabel
+            ? intl.closeOsdControlPanelLabel
+            : intl.openOsdControlPanelLabel
         "
         (click)="toggleFab()"
       >

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
@@ -1,5 +1,5 @@
 <div #container class="osd-toolbar" [ngStyle]="osdToolbarStyle">
-  <div *ngIf="isWeb" class="osd-toolbar-container flex-col">
+  <div *ngIf="isWeb" class="flex-col">
     <ng-container *ngIf="invert">
       <button
         data-testid="navigateBeforeButton"

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
@@ -1,11 +1,17 @@
 <div #container class="osd-toolbar">
   <div *ngIf="isWeb" class="flex gap-2">
     <div class="flex flex-col gap-2">
-      <button mat-fab (click)="onFabClick()" data-testid="fabButton">
+      <button
+        mat-fab
+        aria-controls="osdControls"
+        data-testid="fabButton"
+        [attr.aria-expanded]="fabState === 'open'"
+        (click)="onFabClick()"
+      >
         <mat-icon [@rotate45]="fabState">{{ fabIcon }}</mat-icon>
       </button>
     </div>
-    <div class="flex items-center gap-2">
+    <div id="osdControls" class="flex items-center gap-2">
       <ng-container *ngIf="invert">
         <button
           *ngIf="showControlButtons"

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
@@ -6,7 +6,7 @@
         aria-controls="osdControls"
         data-testid="fabButton"
         [attr.aria-expanded]="fabState === 'open'"
-        [attr.aria-label]='intl.osdControlsAriaLabel'
+        [attr.aria-label]="intl.osdControlsAriaLabel"
         (click)="onFabClick()"
       >
         <mat-icon [@rotate45]="fabState">{{ fabIcon }}</mat-icon>

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
@@ -94,6 +94,7 @@
         data-testid="homeButton"
         mat-mini-fab
         [attr.aria-label]="intl.homeLabel"
+        [disabled]='!isZoomed'
         [matTooltip]="intl.homeLabel"
         [@OsdControlsState]="{
           value: '',

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
@@ -6,6 +6,7 @@
         aria-controls="osdControls"
         data-testid="fabButton"
         [attr.aria-expanded]="fabState === 'open'"
+        [attr.aria-label]='intl.osdControlsAriaLabel'
         (click)="onFabClick()"
       >
         <mat-icon [@rotate45]="fabState">{{ fabIcon }}</mat-icon>
@@ -108,9 +109,9 @@
         (click)="home()"
         data-testid="homeButton"
         mat-mini-fab
-        [attr.aria-label]="intl.homeLabel"
+        [attr.aria-label]="intl.zoomHomeLabel"
         [disabled]="!isZoomed"
-        [matTooltip]="intl.homeLabel"
+        [matTooltip]="intl.zoomHomeLabel"
         [@easeInWithDelay]="{
           value: '',
           params: {

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
@@ -8,7 +8,7 @@
     <div class="flex items-center gap-2">
       <ng-container *ngIf="invert">
         <button
-          *ngIf="showControls"
+          *ngIf="showControlButtons"
           data-testid="navigateBeforeButton"
           mat-mini-fab
           [attr.aria-label]="intl.previousPageLabel"
@@ -16,7 +16,7 @@
           [disabled]="isFirstCanvasGroup"
           [@OsdControlsState]="{
             value: '',
-            params: { delayEnter: 0, delayLeave: baseDelay * 5 }
+            params: { delayEnter: 0, delayLeave: baseAnimationDelay * 5 }
           }"
           (click)="goToPreviousCanvasGroup()"
         >
@@ -25,7 +25,7 @@
       </ng-container>
       <ng-container *ngIf="!invert">
         <button
-          *ngIf="showControls"
+          *ngIf="showControlButtons"
           data-testid="navigateNextButton"
           mat-mini-fab
           [attr.aria-label]="intl.nextPageLabel"
@@ -33,7 +33,7 @@
           [disabled]="isLastCanvasGroup"
           [@OsdControlsState]="{
             value: '',
-            params: { delayEnter: 0, delayLeave: baseDelay * 5 }
+            params: { delayEnter: 0, delayLeave: baseAnimationDelay * 5 }
           }"
           (click)="goToNextCanvasGroup()"
         >
@@ -42,7 +42,7 @@
       </ng-container>
       <ng-container *ngIf="invert">
         <button
-          *ngIf="showControls"
+          *ngIf="showControlButtons"
           data-testid="navigateNextButton"
           mat-mini-fab
           [attr.aria-label]="intl.nextPageLabel"
@@ -50,7 +50,7 @@
           [disabled]="isLastCanvasGroup"
           [@OsdControlsState]="{
             value: '',
-            params: { delayEnter: baseDelay, delayLeave: baseDelay * 4 }
+            params: { delayEnter: baseAnimationDelay, delayLeave: baseAnimationDelay * 4 }
           }"
           (click)="goToNextCanvasGroup()"
         >
@@ -59,7 +59,7 @@
       </ng-container>
       <ng-container *ngIf="!invert">
         <button
-          *ngIf="showControls"
+          *ngIf="showControlButtons"
           data-testid="navigateBeforeButton"
           mat-mini-fab
           [attr.aria-label]="intl.previousPageLabel"
@@ -67,7 +67,7 @@
           [disabled]="isFirstCanvasGroup"
           [@OsdControlsState]="{
             value: '',
-            params: { delayEnter: baseDelay, delayLeave: baseDelay * 4 }
+            params: { delayEnter: baseAnimationDelay, delayLeave: baseAnimationDelay * 4 }
           }"
           (click)="goToPreviousCanvasGroup()"
         >
@@ -75,7 +75,7 @@
         </button>
       </ng-container>
       <button
-        *ngIf="showControls"
+        *ngIf="showControlButtons"
         (click)="zoomIn()"
         data-testid="zoomInButton"
         mat-mini-fab
@@ -83,13 +83,13 @@
         [matTooltip]="intl.zoomInLabel"
         [@OsdControlsState]="{
           value: '',
-          params: { delayEnter: baseDelay * 2, delayLeave: baseDelay * 3 }
+          params: { delayEnter: baseAnimationDelay * 2, delayLeave: baseAnimationDelay * 3 }
         }"
       >
         <mat-icon>zoom_in</mat-icon>
       </button>
       <button
-        *ngIf="showControls"
+        *ngIf="showControlButtons"
         (click)="home()"
         data-testid="homeButton"
         mat-mini-fab
@@ -98,13 +98,13 @@
         [matTooltip]="intl.homeLabel"
         [@OsdControlsState]="{
           value: '',
-          params: { delayEnter: baseDelay * 3, delayLeave: baseDelay * 2 }
+          params: { delayEnter: baseAnimationDelay * 3, delayLeave: baseAnimationDelay * 2 }
         }"
       >
         <mat-icon>home</mat-icon>
       </button>
       <button
-        *ngIf="showControls"
+        *ngIf="showControlButtons"
         (click)="zoomOut()"
         data-testid="zoomOutButton"
         mat-mini-fab
@@ -112,13 +112,13 @@
         [matTooltip]="intl.zoomOutLabel"
         [@OsdControlsState]="{
           value: '',
-          params: { delayEnter: baseDelay * 4, delayLeave: baseDelay }
+          params: { delayEnter: baseAnimationDelay * 4, delayLeave: baseAnimationDelay }
         }"
       >
         <mat-icon>zoom_out</mat-icon>
       </button>
       <button
-        *ngIf="showControls"
+        *ngIf="showControlButtons"
         (click)="rotate()"
         data-testid="rotateButton"
         mat-mini-fab
@@ -126,7 +126,7 @@
         [matTooltip]="intl.rotateCwLabel"
         [@OsdControlsState]="{
           value: '',
-          params: { delayEnter: baseDelay * 5, delayLeave: 0 }
+          params: { delayEnter: baseAnimationDelay * 5, delayLeave: 0 }
         }"
       >
         <mat-icon>rotate_right</mat-icon>

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
@@ -50,7 +50,10 @@
           [disabled]="isLastCanvasGroup"
           [@easeInWithDelay]="{
             value: '',
-            params: { delayEnter: baseAnimationDelay, delayLeave: baseAnimationDelay * 4 }
+            params: {
+              delayEnter: baseAnimationDelay,
+              delayLeave: baseAnimationDelay * 4
+            }
           }"
           (click)="goToNextCanvasGroup()"
         >
@@ -67,7 +70,10 @@
           [disabled]="isFirstCanvasGroup"
           [@easeInWithDelay]="{
             value: '',
-            params: { delayEnter: baseAnimationDelay, delayLeave: baseAnimationDelay * 4 }
+            params: {
+              delayEnter: baseAnimationDelay,
+              delayLeave: baseAnimationDelay * 4
+            }
           }"
           (click)="goToPreviousCanvasGroup()"
         >
@@ -83,7 +89,10 @@
         [matTooltip]="intl.zoomInLabel"
         [@easeInWithDelay]="{
           value: '',
-          params: { delayEnter: baseAnimationDelay * 2, delayLeave: baseAnimationDelay * 3 }
+          params: {
+            delayEnter: baseAnimationDelay * 2,
+            delayLeave: baseAnimationDelay * 3
+          }
         }"
       >
         <mat-icon>zoom_in</mat-icon>
@@ -94,11 +103,14 @@
         data-testid="homeButton"
         mat-mini-fab
         [attr.aria-label]="intl.homeLabel"
-        [disabled]='!isZoomed'
+        [disabled]="!isZoomed"
         [matTooltip]="intl.homeLabel"
         [@easeInWithDelay]="{
           value: '',
-          params: { delayEnter: baseAnimationDelay * 3, delayLeave: baseAnimationDelay * 2 }
+          params: {
+            delayEnter: baseAnimationDelay * 3,
+            delayLeave: baseAnimationDelay * 2
+          }
         }"
       >
         <mat-icon>home</mat-icon>
@@ -112,7 +124,10 @@
         [matTooltip]="intl.zoomOutLabel"
         [@easeInWithDelay]="{
           value: '',
-          params: { delayEnter: baseAnimationDelay * 4, delayLeave: baseAnimationDelay }
+          params: {
+            delayEnter: baseAnimationDelay * 4,
+            delayLeave: baseAnimationDelay
+          }
         }"
       >
         <mat-icon>zoom_out</mat-icon>

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
@@ -2,7 +2,7 @@
   <div *ngIf="isWeb" class="flex gap-2">
     <div class="flex flex-col gap-2">
       <button mat-fab (click)="onFabClick()" data-testid="fabButton">
-        <mat-icon [@fabOpenState]="fabState">{{ fabIcon }}</mat-icon>
+        <mat-icon [@rotate45]="fabState">{{ fabIcon }}</mat-icon>
       </button>
     </div>
     <div class="flex items-center gap-2">
@@ -14,7 +14,7 @@
           [attr.aria-label]="intl.previousPageLabel"
           [matTooltip]="intl.previousPageLabel"
           [disabled]="isFirstCanvasGroup"
-          [@OsdControlsState]="{
+          [@easeInWithDelay]="{
             value: '',
             params: { delayEnter: 0, delayLeave: baseAnimationDelay * 5 }
           }"
@@ -31,7 +31,7 @@
           [attr.aria-label]="intl.nextPageLabel"
           [matTooltip]="intl.nextPageLabel"
           [disabled]="isLastCanvasGroup"
-          [@OsdControlsState]="{
+          [@easeInWithDelay]="{
             value: '',
             params: { delayEnter: 0, delayLeave: baseAnimationDelay * 5 }
           }"
@@ -48,7 +48,7 @@
           [attr.aria-label]="intl.nextPageLabel"
           [matTooltip]="intl.nextPageLabel"
           [disabled]="isLastCanvasGroup"
-          [@OsdControlsState]="{
+          [@easeInWithDelay]="{
             value: '',
             params: { delayEnter: baseAnimationDelay, delayLeave: baseAnimationDelay * 4 }
           }"
@@ -65,7 +65,7 @@
           [attr.aria-label]="intl.previousPageLabel"
           [matTooltip]="intl.previousPageLabel"
           [disabled]="isFirstCanvasGroup"
-          [@OsdControlsState]="{
+          [@easeInWithDelay]="{
             value: '',
             params: { delayEnter: baseAnimationDelay, delayLeave: baseAnimationDelay * 4 }
           }"
@@ -81,7 +81,7 @@
         mat-mini-fab
         [attr.aria-label]="intl.zoomInLabel"
         [matTooltip]="intl.zoomInLabel"
-        [@OsdControlsState]="{
+        [@easeInWithDelay]="{
           value: '',
           params: { delayEnter: baseAnimationDelay * 2, delayLeave: baseAnimationDelay * 3 }
         }"
@@ -96,7 +96,7 @@
         [attr.aria-label]="intl.homeLabel"
         [disabled]='!isZoomed'
         [matTooltip]="intl.homeLabel"
-        [@OsdControlsState]="{
+        [@easeInWithDelay]="{
           value: '',
           params: { delayEnter: baseAnimationDelay * 3, delayLeave: baseAnimationDelay * 2 }
         }"
@@ -110,7 +110,7 @@
         mat-mini-fab
         [attr.aria-label]="intl.zoomOutLabel"
         [matTooltip]="intl.zoomOutLabel"
-        [@OsdControlsState]="{
+        [@easeInWithDelay]="{
           value: '',
           params: { delayEnter: baseAnimationDelay * 4, delayLeave: baseAnimationDelay }
         }"
@@ -124,7 +124,7 @@
         mat-mini-fab
         [attr.aria-label]="intl.rotateCwLabel"
         [matTooltip]="intl.rotateCwLabel"
-        [@OsdControlsState]="{
+        [@easeInWithDelay]="{
           value: '',
           params: { delayEnter: baseAnimationDelay * 5, delayLeave: 0 }
         }"

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
@@ -7,7 +7,7 @@
         data-testid="fabButton"
         [attr.aria-expanded]="fabState === 'open'"
         [attr.aria-label]="intl.osdControlsAriaLabel"
-        (click)="onFabClick()"
+        (click)="toggleFab()"
       >
         <mat-icon [@rotate45]="fabState">{{ fabIcon }}</mat-icon>
       </button>

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.html
@@ -1,89 +1,135 @@
-<div #container class="osd-toolbar" [ngStyle]="osdToolbarStyle">
-  <div *ngIf="isWeb" class="flex-col">
-    <ng-container *ngIf="invert">
-      <button
-        data-testid="navigateBeforeButton"
-        mat-icon-button
-        [attr.aria-label]="intl.previousPageLabel"
-        [matTooltip]="intl.previousPageLabel"
-        [disabled]="isFirstCanvasGroup"
-        (click)="goToPreviousCanvasGroup()"
-      >
-        <mat-icon>navigate_before</mat-icon>
+<div #container class="osd-toolbar">
+  <div *ngIf="isWeb" class="flex gap-2">
+    <div class="flex flex-col gap-2">
+      <button mat-fab (click)="onFabClick()">
+        <mat-icon [@fabOpenState]="fabOpenState">{{ fabOpenState }}</mat-icon>
       </button>
-    </ng-container>
-    <ng-container *ngIf="!invert">
+    </div>
+    <div class="flex items-center gap-2">
+      <ng-container *ngIf="invert">
+        <button
+          *ngIf="showControls"
+          data-testid="navigateBeforeButton"
+          mat-mini-fab
+          [attr.aria-label]="intl.previousPageLabel"
+          [matTooltip]="intl.previousPageLabel"
+          [disabled]="isFirstCanvasGroup"
+          [@OsdControlsState]="{
+            value: '',
+            params: { delayEnter: 0, delayLeave: baseDelay * 5 }
+          }"
+          (click)="goToPreviousCanvasGroup()"
+        >
+          <mat-icon>navigate_before</mat-icon>
+        </button>
+      </ng-container>
+      <ng-container *ngIf="!invert">
+        <button
+          *ngIf="showControls"
+          data-testid="navigateNextButton"
+          mat-mini-fab
+          [attr.aria-label]="intl.nextPageLabel"
+          [matTooltip]="intl.nextPageLabel"
+          [disabled]="isLastCanvasGroup"
+          [@OsdControlsState]="{
+            value: '',
+            params: { delayEnter: 0, delayLeave: baseDelay * 5 }
+          }"
+          (click)="goToNextCanvasGroup()"
+        >
+          <mat-icon>navigate_before</mat-icon>
+        </button>
+      </ng-container>
+      <ng-container *ngIf="invert">
+        <button
+          *ngIf="showControls"
+          data-testid="navigateNextButton"
+          mat-mini-fab
+          [attr.aria-label]="intl.nextPageLabel"
+          [matTooltip]="intl.nextPageLabel"
+          [disabled]="isLastCanvasGroup"
+          [@OsdControlsState]="{
+            value: '',
+            params: { delayEnter: baseDelay, delayLeave: baseDelay * 4 }
+          }"
+          (click)="goToNextCanvasGroup()"
+        >
+          <mat-icon>navigate_next</mat-icon>
+        </button>
+      </ng-container>
+      <ng-container *ngIf="!invert">
+        <button
+          *ngIf="showControls"
+          data-testid="navigateBeforeButton"
+          mat-mini-fab
+          [attr.aria-label]="intl.previousPageLabel"
+          [matTooltip]="intl.previousPageLabel"
+          [disabled]="isFirstCanvasGroup"
+          [@OsdControlsState]="{
+            value: '',
+            params: { delayEnter: baseDelay, delayLeave: baseDelay * 4 }
+          }"
+          (click)="goToPreviousCanvasGroup()"
+        >
+          <mat-icon>navigate_next</mat-icon>
+        </button>
+      </ng-container>
       <button
-        data-testid="navigateNextButton"
-        mat-icon-button
-        [attr.aria-label]="intl.nextPageLabel"
-        [matTooltip]="intl.nextPageLabel"
-        [disabled]="isLastCanvasGroup"
-        (click)="goToNextCanvasGroup()"
+        *ngIf="showControls"
+        (click)="zoomIn()"
+        data-testid="zoomInButton"
+        mat-mini-fab
+        [attr.aria-label]="intl.zoomInLabel"
+        [matTooltip]="intl.zoomInLabel"
+        [@OsdControlsState]="{
+          value: '',
+          params: { delayEnter: baseDelay * 2, delayLeave: baseDelay * 3 }
+        }"
       >
-        <mat-icon>navigate_before</mat-icon>
+        <mat-icon>zoom_in</mat-icon>
       </button>
-    </ng-container>
-    <button
-      (click)="home()"
-      data-testid="homeButton"
-      mat-icon-button
-      [attr.aria-label]="intl.homeLabel"
-      [matTooltip]="intl.homeLabel"
-    >
-      <mat-icon>home</mat-icon>
-    </button>
-    <ng-container *ngIf="invert">
       <button
-        data-testid="navigateNextButton"
-        mat-icon-button
-        [attr.aria-label]="intl.nextPageLabel"
-        [matTooltip]="intl.nextPageLabel"
-        [disabled]="isLastCanvasGroup"
-        (click)="goToNextCanvasGroup()"
+        *ngIf="showControls"
+        (click)="home()"
+        data-testid="homeButton"
+        mat-mini-fab
+        [attr.aria-label]="intl.homeLabel"
+        [matTooltip]="intl.homeLabel"
+        [@OsdControlsState]="{
+          value: '',
+          params: { delayEnter: baseDelay * 3, delayLeave: baseDelay * 2 }
+        }"
       >
-        <mat-icon>navigate_next</mat-icon>
+        <mat-icon>home</mat-icon>
       </button>
-    </ng-container>
-    <ng-container *ngIf="!invert">
       <button
-        data-testid="navigateBeforeButton"
-        mat-icon-button
-        [attr.aria-label]="intl.previousPageLabel"
-        [matTooltip]="intl.previousPageLabel"
-        [disabled]="isFirstCanvasGroup"
-        (click)="goToPreviousCanvasGroup()"
+        *ngIf="showControls"
+        (click)="zoomOut()"
+        data-testid="zoomOutButton"
+        mat-mini-fab
+        [attr.aria-label]="intl.zoomOutLabel"
+        [matTooltip]="intl.zoomOutLabel"
+        [@OsdControlsState]="{
+          value: '',
+          params: { delayEnter: baseDelay * 4, delayLeave: baseDelay }
+        }"
       >
-        <mat-icon>navigate_next</mat-icon>
+        <mat-icon>zoom_out</mat-icon>
       </button>
-    </ng-container>
-    <button
-      (click)="zoomIn()"
-      data-testid="zoomInButton"
-      mat-icon-button
-      [attr.aria-label]="intl.zoomInLabel"
-      [matTooltip]="intl.zoomInLabel"
-    >
-      <mat-icon>zoom_in</mat-icon>
-    </button>
-
-    <button
-      (click)="rotate()"
-      data-testid="rotateButton"
-      mat-icon-button
-      [attr.aria-label]="intl.rotateCwLabel"
-      [matTooltip]="intl.rotateCwLabel"
-    >
-      <mat-icon>rotate_right</mat-icon>
-    </button>
-    <button
-      (click)="zoomOut()"
-      data-testid="zoomOutButton"
-      mat-icon-button
-      [attr.aria-label]="intl.zoomOutLabel"
-      [matTooltip]="intl.zoomOutLabel"
-    >
-      <mat-icon>zoom_out</mat-icon>
-    </button>
+      <button
+        *ngIf="showControls"
+        (click)="rotate()"
+        data-testid="rotateButton"
+        mat-mini-fab
+        [attr.aria-label]="intl.rotateCwLabel"
+        [matTooltip]="intl.rotateCwLabel"
+        [@OsdControlsState]="{
+          value: '',
+          params: { delayEnter: baseDelay * 5, delayLeave: 0 }
+        }"
+      >
+        <mat-icon>rotate_right</mat-icon>
+      </button>
+    </div>
   </div>
 </div>

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.scss
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.scss
@@ -11,5 +11,4 @@
   background: transparent;
   width: auto;
   border-radius: 8px;
-  margin-left: 16px;
 }

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.scss
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.scss
@@ -2,10 +2,6 @@
   z-index: 2;
 }
 
-::ng-deep .osd-toolbar-row > .mat-toolbar-row {
-  height: 40px;
-}
-
 .osd-toolbar {
   position: absolute;
   background: transparent;

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.scss
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.scss
@@ -7,4 +7,5 @@
   background: transparent;
   width: auto;
   border-radius: 8px;
+  margin: 8px 0 0 8px;
 }

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
@@ -72,21 +72,19 @@ describe('OsdToolbarComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('Fab button for toggling OSD controls', () => {
-    it('should open and close osd controls when clicked', async () => {
-      await toggleOsdMenu();
+  it('should toggle OSD controls when FAB button is clicked', async () => {
+    await toggleOsdControls();
 
-      await expectOsdControlsTobeVisible();
+    await expectOsdControlsTobeVisible();
 
-      await toggleOsdMenu();
+    await toggleOsdControls();
 
-      await expectOsdControlsTobeHidden();
-    });
+    await expectOsdControlsTobeHidden();
   });
 
-  describe('Osd controls', () => {
+  describe('OSD controls', () => {
     it('should re-render when the i18n labels have changed', async () => {
-      await toggleOsdMenu();
+      await toggleOsdControls();
       const homeButton = await getHomeButton();
       intl.homeLabel = 'Go home button';
 
@@ -102,7 +100,7 @@ describe('OsdToolbarComponent', () => {
       viewerService.setCanvasGroupIndexChange(0);
       fixture.detectChanges();
 
-      await toggleOsdMenu();
+      await toggleOsdControls();
       const previousButton = await getPreviousButton();
       expect(await previousButton.isDisabled()).toBeTrue();
     });
@@ -111,7 +109,7 @@ describe('OsdToolbarComponent', () => {
       viewerService.setCanvasGroupIndexChange(1);
       fixture.detectChanges();
 
-      await toggleOsdMenu();
+      await toggleOsdControls();
       const previousButton = await getPreviousButton();
       const nextButton = await getNextButton();
 
@@ -130,7 +128,7 @@ describe('OsdToolbarComponent', () => {
       fixture.detectChanges();
 
       fixture.whenStable().then(async () => {
-        await toggleOsdMenu();
+        await toggleOsdControls();
         const nextButton = await getNextButton();
         expect(await nextButton.isDisabled()).toBeTrue();
       });
@@ -139,7 +137,7 @@ describe('OsdToolbarComponent', () => {
     it('should display next canvas group', waitForAsync(async () => {
       spy = spyOn(viewerService, 'goToNextCanvasGroup');
 
-      await toggleOsdMenu();
+      await toggleOsdControls();
       const nextButton = await getNextButton();
       await nextButton.click();
 
@@ -152,7 +150,7 @@ describe('OsdToolbarComponent', () => {
     it('should display previous canvas group', waitForAsync(async () => {
       spy = spyOn(component, 'goToPreviousCanvasGroup');
 
-      await toggleOsdMenu();
+      await toggleOsdControls();
       const previousButton = await getPreviousButton();
       await previousButton.click();
 
@@ -163,14 +161,14 @@ describe('OsdToolbarComponent', () => {
     }));
 
     it('should disable home zoom button when zoom level is home', async () => {
-      await toggleOsdMenu();
+      await toggleOsdControls();
       const homeButton = await getHomeButton();
 
       expect(await homeButton.isDisabled()).toBeTrue();
     });
 
     it('should enable home zoom button when page is zoomed in', async () => {
-      await toggleOsdMenu();
+      await toggleOsdControls();
 
       const zoomInButton = await getZoomInButton();
       await zoomInButton.click();
@@ -180,7 +178,7 @@ describe('OsdToolbarComponent', () => {
     });
   });
 
-  const toggleOsdMenu = async (): Promise<void> =>
+  const toggleOsdControls = async (): Promise<void> =>
     await (await getButtonByTestId('fabButton')).click();
 
   const getHomeButton = (): Promise<MatButtonHarness> =>

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
@@ -98,7 +98,7 @@ describe('OsdToolbarComponent', () => {
     it('should re-render when the i18n labels have changed', async () => {
       await toggleOsdControls();
       const homeButton = await getHomeButton();
-      intl.zoomHomeLabel = 'Go home button';
+      intl.resetZoomLabel = 'Go home button';
 
       intl.changes.next();
       fixture.detectChanges();

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
@@ -213,10 +213,12 @@ describe('OsdToolbarComponent', () => {
       MatButtonHarness.with({ selector: `[data-testid="${id}"]` })
     );
 
-  const expectFabButtonToHaveAriaExpanded = async (expected: string): Promise<void> => {
+  const expectFabButtonToHaveAriaExpanded = async (
+    expected: string
+  ): Promise<void> => {
     const fabButton = await (await getFabButton()).host();
     expect(await fabButton.getAttribute('aria-expanded')).toEqual(expected);
-  }
+  };
 
   const expectOsdControlsTobeVisible = async () => {
     const buttons = await getMiniFabButtons();

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
@@ -83,7 +83,7 @@ describe('OsdToolbarComponent', () => {
       await expectFabButtonToHaveAriaExpanded('true');
     });
 
-    it('should toggle OSD controls when FAB button is clicked', async () => {
+    it('should toggle OSD controls when clicked', async () => {
       await toggleOsdControls();
 
       await expectOsdControlsTobeVisible();

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
@@ -98,7 +98,7 @@ describe('OsdToolbarComponent', () => {
     it('should re-render when the i18n labels have changed', async () => {
       await toggleOsdControls();
       const homeButton = await getHomeButton();
-      intl.homeLabel = 'Go home button';
+      intl.zoomHomeLabel = 'Go home button';
 
       intl.changes.next();
       fixture.detectChanges();

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
@@ -72,14 +72,26 @@ describe('OsdToolbarComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should toggle OSD controls when FAB button is clicked', async () => {
-    await toggleOsdControls();
+  describe('FAB button', () => {
+    it('should have aria-expanded false when closed', async () => {
+      await expectFabButtonToHaveAriaExpanded('false');
+    });
 
-    await expectOsdControlsTobeVisible();
+    it('should have aria-expanded true when open', async () => {
+      await toggleOsdControls();
 
-    await toggleOsdControls();
+      await expectFabButtonToHaveAriaExpanded('true');
+    });
 
-    await expectOsdControlsTobeHidden();
+    it('should toggle OSD controls when FAB button is clicked', async () => {
+      await toggleOsdControls();
+
+      await expectOsdControlsTobeVisible();
+
+      await toggleOsdControls();
+
+      await expectOsdControlsTobeHidden();
+    });
   });
 
   describe('OSD controls', () => {
@@ -179,7 +191,10 @@ describe('OsdToolbarComponent', () => {
   });
 
   const toggleOsdControls = async (): Promise<void> =>
-    await (await getButtonByTestId('fabButton')).click();
+    await (await getFabButton()).click();
+
+  const getFabButton = (): Promise<MatButtonHarness> =>
+    getButtonByTestId('fabButton');
 
   const getHomeButton = (): Promise<MatButtonHarness> =>
     getButtonByTestId('homeButton');
@@ -197,6 +212,11 @@ describe('OsdToolbarComponent', () => {
     harnessLoader.getHarness(
       MatButtonHarness.with({ selector: `[data-testid="${id}"]` })
     );
+
+  const expectFabButtonToHaveAriaExpanded = async (expected: string): Promise<void> => {
+    const fabButton = await (await getFabButton()).host();
+    expect(await fabButton.getAttribute('aria-expanded')).toEqual(expected);
+  }
 
   const expectOsdControlsTobeVisible = async () => {
     const buttons = await getMiniFabButtons();

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
@@ -73,34 +73,6 @@ describe('OsdToolbarComponent', () => {
   });
 
   describe('Fab button for toggling OSD controls', () => {
-    it("should not be visible when state is changed to 'hide'", waitForAsync(() => {
-      component.state = 'show';
-      fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        expectFabButtonToBeVisible();
-
-        component.state = 'hide';
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          expectFabButtonToBeHidden();
-        });
-      });
-    }));
-
-    it("should be visible when state is changed to 'show'", waitForAsync(() => {
-      component.state = 'hide';
-      fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        expectFabButtonToBeHidden();
-
-        component.state = 'show';
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          expectFabButtonToBeVisible();
-        });
-      });
-    }));
-
     it('should open and close osd controls when clicked', async () => {
       await toggleOsdMenu();
 
@@ -227,18 +199,6 @@ describe('OsdToolbarComponent', () => {
     harnessLoader.getHarness(
       MatButtonHarness.with({ selector: `[data-testid="${id}"]` })
     );
-
-  const expectFabButtonToBeVisible = () => {
-    expect(fixture.debugElement.nativeElement.style.transform).toBe(
-      'translate(0px, 0px)'
-    );
-  };
-
-  const expectFabButtonToBeHidden = () => {
-    expect(fixture.debugElement.nativeElement.style.transform).toBe(
-      'translate(-100%, 0px)'
-    );
-  };
 
   const expectOsdControlsTobeVisible = async () => {
     const buttons = await getMiniFabButtons();

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.spec.ts
@@ -1,7 +1,10 @@
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
 import { injectedStub } from '../../../testing/injected-stub';
 import { CanvasService } from '../../core/canvas-service/canvas-service';
 import { ClickService } from '../../core/click-service/click.service';
@@ -19,11 +22,8 @@ import { MockBreakpointObserver } from '../../test/mock-breakpoint-observer';
 import { CanvasServiceStub } from './../../test/canvas-service-stub';
 import { ViewerServiceStub } from './../../test/viewer-service-stub';
 import { OsdToolbarComponent } from './osd-toolbar.component';
-import { HarnessLoader } from '@angular/cdk/testing';
-import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { MatButtonHarness } from '@angular/material/button/testing';
 
-fdescribe('OsdToolbarComponent', () => {
+describe('OsdToolbarComponent', () => {
   let component: OsdToolbarComponent;
   let fixture: ComponentFixture<OsdToolbarComponent>;
   let spy: any;
@@ -31,7 +31,7 @@ fdescribe('OsdToolbarComponent', () => {
   let intl: MimeViewerIntl;
   let canvasService: CanvasServiceStub;
   let viewerService: ViewerServiceStub;
-  let harnessLoader: HarnessLoader
+  let harnessLoader: HarnessLoader;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -148,9 +148,11 @@ fdescribe('OsdToolbarComponent', () => {
     });
 
     it('should disable next button when viewer is on last canvas group', waitForAsync(async () => {
-      spyOnProperty(canvasService, 'numberOfCanvasGroups', 'get').and.returnValue(
-        10
-      );
+      spyOnProperty(
+        canvasService,
+        'numberOfCanvasGroups',
+        'get'
+      ).and.returnValue(10);
 
       viewerService.setCanvasGroupIndexChange(9);
       fixture.detectChanges();
@@ -194,25 +196,48 @@ fdescribe('OsdToolbarComponent', () => {
 
       expect(await homeButton.isDisabled()).toBeTrue();
     });
+
+    it('should enable home zoom button when page is zoomed in', async () => {
+      await toggleOsdMenu();
+
+      const zoomInButton = await getZoomInButton();
+      await zoomInButton.click();
+
+      const homeButton = await getHomeButton();
+      expect(await homeButton.isDisabled()).toBeTrue();
+    });
   });
 
-  const toggleOsdMenu = async (): Promise<void> => await (await getButtonByTestId('fabButton')).click()
+  const toggleOsdMenu = async (): Promise<void> =>
+    await (await getButtonByTestId('fabButton')).click();
 
-  const getHomeButton = (): Promise<MatButtonHarness> => getButtonByTestId('homeButton')
+  const getHomeButton = (): Promise<MatButtonHarness> =>
+    getButtonByTestId('homeButton');
 
-  const getPreviousButton = (): Promise<MatButtonHarness> => getButtonByTestId('navigateBeforeButton');
+  const getPreviousButton = (): Promise<MatButtonHarness> =>
+    getButtonByTestId('navigateBeforeButton');
 
-  const getNextButton = (): Promise<MatButtonHarness> => getButtonByTestId('navigateNextButton')
+  const getNextButton = (): Promise<MatButtonHarness> =>
+    getButtonByTestId('navigateNextButton');
+
+  const getZoomInButton = (): Promise<MatButtonHarness> =>
+    getButtonByTestId('zoomInButton');
 
   const getButtonByTestId = (id: string): Promise<MatButtonHarness> =>
-    harnessLoader.getHarness(MatButtonHarness.with({ selector: `[data-testid="${id}"]` }));
+    harnessLoader.getHarness(
+      MatButtonHarness.with({ selector: `[data-testid="${id}"]` })
+    );
 
   const expectFabButtonToBeVisible = () => {
-    expect(fixture.debugElement.nativeElement.style.transform).toBe('translate(0px, 0px)');
+    expect(fixture.debugElement.nativeElement.style.transform).toBe(
+      'translate(0px, 0px)'
+    );
   };
 
   const expectFabButtonToBeHidden = () => {
-    expect(fixture.debugElement.nativeElement.style.transform).toBe('translate(-100%, 0px)');
+    expect(fixture.debugElement.nativeElement.style.transform).toBe(
+      'translate(-100%, 0px)'
+    );
   };
 
   const expectOsdControlsTobeVisible = async () => {
@@ -226,6 +251,8 @@ fdescribe('OsdToolbarComponent', () => {
   };
 
   const getMiniFabButtons = (): Promise<MatButtonHarness[]> => {
-    return harnessLoader.getAllHarnesses(MatButtonHarness.with({variant: 'mini-fab'}));
-  }
+    return harnessLoader.getAllHarnesses(
+      MatButtonHarness.with({ variant: 'mini-fab' })
+    );
+  };
 });

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.theme.scss
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.theme.scss
@@ -4,7 +4,8 @@
   $accent: map-get($theme, accent);
 
   .osd-toolbar {
-    .mat-mdc-fab, .mat-mdc-mini-fab {
+    .mat-mdc-fab,
+    .mat-mdc-mini-fab {
       background-color: mat.get-color-from-palette($accent, 0.5);
     }
   }

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.theme.scss
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.theme.scss
@@ -1,0 +1,11 @@
+@use '@angular/material' as mat;
+
+@mixin osd-toolbar-component-theme($theme) {
+  $accent: map-get($theme, accent);
+
+  .osd-toolbar {
+    .mat-mdc-fab, .mat-mdc-mini-fab {
+      background-color: mat.get-color-from-palette($accent, 0.5);
+    }
+  }
+}

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
@@ -65,7 +65,7 @@ export class OsdToolbarComponent implements OnInit, OnDestroy {
       this.breakpointObserver
         .observe([Breakpoints.Web])
         .subscribe((value: BreakpointState) => {
-          (this.isWeb = value.matches)
+          this.isWeb = value.matches;
           this.changeDetectorRef.detectChanges();
         })
     );

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
@@ -64,7 +64,10 @@ export class OsdToolbarComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.breakpointObserver
         .observe([Breakpoints.Web])
-        .subscribe((value: BreakpointState) => (this.isWeb = value.matches))
+        .subscribe((value: BreakpointState) => {
+          (this.isWeb = value.matches)
+          this.changeDetectorRef.detectChanges();
+        })
     );
 
     this.subscriptions.add(

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
@@ -101,7 +101,7 @@ export class OsdToolbarComponent implements OnInit, OnDestroy {
     );
   }
 
-  onFabClick(): void {
+  toggleFab(): void {
     this.showControlButtons = !this.showControlButtons;
     this.fabState = this.fabState === 'closed' ? 'open' : 'closed';
     this.fabIcon = this.fabState === 'closed' ? 'menu' : 'clear';

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
@@ -8,7 +8,6 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
-  HostBinding,
   OnDestroy,
   OnInit,
   ViewChild,
@@ -24,7 +23,6 @@ import { ModeService } from './../../core/mode-service/mode.service';
 import {
   easeInWithDelay,
   rotate45,
-  slideInLeft,
 } from './../../viewer/osd-toolbar/animations';
 
 @Component({
@@ -32,18 +30,13 @@ import {
   templateUrl: './osd-toolbar.component.html',
   styleUrls: ['./osd-toolbar.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  animations: [slideInLeft, rotate45, easeInWithDelay],
+  animations: [rotate45, easeInWithDelay],
 })
 export class OsdToolbarComponent implements OnInit, OnDestroy {
   @ViewChild('container', { static: true }) container!: ElementRef;
-  @HostBinding('@slideInLeft')
-  get osdFabState() {
-    return this.state;
-  }
   public numberOfCanvasGroups = 0;
   public isFirstCanvasGroup = false;
   public isLastCanvasGroup = false;
-  public state = 'hide';
   invert = false;
   isWeb = false;
   fabState = 'closed';

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
@@ -115,15 +115,6 @@ export class OsdToolbarComponent implements OnInit, AfterViewInit, OnDestroy {
     );
 
     this.subscriptions.add(
-      this.mimeService.onResize.subscribe((dimensions: Dimensions) => {
-        this.osdToolbarStyle = {
-          top: dimensions.top + 110 + 'px',
-        };
-        this.changeDetectorRef.detectChanges();
-      })
-    );
-
-    this.subscriptions.add(
       this.viewerService.onCanvasGroupIndexChange.subscribe(
         (currentCanvasGroupIndex: number) => {
           this.numberOfCanvasGroups = this.canvasService.numberOfCanvasGroups;

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
@@ -20,10 +20,7 @@ import { CanvasService } from './../../core/canvas-service/canvas-service';
 import { MimeViewerIntl } from './../../core/intl';
 import { ViewerService } from './../../core/viewer-service/viewer.service';
 import { ModeService } from './../../core/mode-service/mode.service';
-import {
-  easeInWithDelay,
-  rotate45,
-} from './../../viewer/osd-toolbar/animations';
+import { easeInWithDelay, rotate45 } from './../../shared/animations';
 
 @Component({
   selector: 'mime-osd-toolbar',

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
@@ -60,7 +60,7 @@ export class OsdToolbarComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.modeService.onChange.subscribe(() => {
         this.isZoomed = this.modeService.isPageZoomed();
-        this.changeDetectorRef.markForCheck();
+        this.changeDetectorRef.detectChanges();
       })
     );
 

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
@@ -28,6 +28,7 @@ import { ViewingDirection } from '../../core/models/viewing-direction';
 import { CanvasService } from './../../core/canvas-service/canvas-service';
 import { MimeViewerIntl } from './../../core/intl';
 import { ViewerService } from './../../core/viewer-service/viewer.service';
+import { ModeService } from './../../core/mode-service/mode.service';
 
 @Component({
   selector: 'mime-osd-toolbar',
@@ -62,11 +63,11 @@ import { ViewerService } from './../../core/viewer-service/viewer.service';
     trigger('fabOpenState', [
       transition('closed => open', [
         style({ transform: 'rotate(-45deg)', opacity: 0 }),
-        animate('200ms')
+        animate('200ms'),
       ]),
       transition('open => closed', [
         style({ transform: 'rotate(45deg)', opacity: 0 }),
-        animate('200ms')
+        animate('200ms'),
       ]),
     ]),
     trigger('OsdControlsState', [
@@ -96,6 +97,7 @@ export class OsdToolbarComponent implements OnInit, OnDestroy {
   fabIcon = 'menu';
   showControls = false;
   baseDelay = 20;
+  isZoomed = true;
   private subscriptions = new Subscription();
 
   constructor(
@@ -104,10 +106,18 @@ export class OsdToolbarComponent implements OnInit, OnDestroy {
     private changeDetectorRef: ChangeDetectorRef,
     private viewerService: ViewerService,
     private canvasService: CanvasService,
-    private iiifManifestService: IiifManifestService
+    private iiifManifestService: IiifManifestService,
+    private modeService: ModeService
   ) {}
 
   ngOnInit() {
+    this.subscriptions.add(
+      this.modeService.onChange.subscribe(() => {
+        this.isZoomed = this.modeService.isPageZoomed();
+        this.changeDetectorRef.markForCheck();
+      })
+    );
+
     this.subscriptions.add(
       this.breakpointObserver
         .observe([Breakpoints.Web])

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
@@ -36,7 +36,7 @@ import {
 })
 export class OsdToolbarComponent implements OnInit, OnDestroy {
   @ViewChild('container', { static: true }) container!: ElementRef;
-  @HostBinding('@osdComponentState')
+  @HostBinding('@slideInLeft')
   get osdFabState() {
     return this.state;
   }

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
@@ -1,11 +1,4 @@
 import {
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
-import {
   BreakpointObserver,
   Breakpoints,
   BreakpointState,
@@ -23,67 +16,27 @@ import {
 import { Subscription } from 'rxjs';
 import { IiifManifestService } from '../../core/iiif-manifest-service/iiif-manifest-service';
 import { Manifest } from '../../core/models/manifest';
-import { ViewerOptions } from '../../core/models/viewer-options';
 import { ViewingDirection } from '../../core/models/viewing-direction';
 import { CanvasService } from './../../core/canvas-service/canvas-service';
 import { MimeViewerIntl } from './../../core/intl';
 import { ViewerService } from './../../core/viewer-service/viewer.service';
 import { ModeService } from './../../core/mode-service/mode.service';
+import {
+  easeInWithDelay,
+  rotate45,
+  slideInLeft,
+} from './../../viewer/osd-toolbar/animations';
 
 @Component({
   selector: 'mime-osd-toolbar',
   templateUrl: './osd-toolbar.component.html',
   styleUrls: ['./osd-toolbar.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  animations: [
-    trigger('osdFabState', [
-      state(
-        'hide',
-        style({
-          transform: 'translate(-100%, 0)',
-          display: 'none',
-        })
-      ),
-      state(
-        'show',
-        style({
-          transform: 'translate(0px, 0px)',
-          display: 'block',
-        })
-      ),
-      transition(
-        'hide => show',
-        animate(`${ViewerOptions.transitions.toolbarsEaseInTime}ms ease-out`)
-      ),
-      transition(
-        'show => hide',
-        animate(`${ViewerOptions.transitions.toolbarsEaseOutTime}ms ease-in`)
-      ),
-    ]),
-    trigger('fabOpenState', [
-      transition('closed => open', [
-        style({ transform: 'rotate(-45deg)', opacity: 0 }),
-        animate('200ms'),
-      ]),
-      transition('open => closed', [
-        style({ transform: 'rotate(45deg)', opacity: 0 }),
-        animate('200ms'),
-      ]),
-    ]),
-    trigger('OsdControlsState', [
-      state('void', style({ transform: 'scale(0)' })),
-      transition(':enter', animate(`1ms {{delayEnter}}ms ease-out`), {
-        params: { delayEnter: 0 },
-      }),
-      transition(':leave', animate(`1ms {{delayLeave}}ms ease-in`), {
-        params: { delayLeave: 0 },
-      }),
-    ]),
-  ],
+  animations: [slideInLeft, rotate45, easeInWithDelay],
 })
 export class OsdToolbarComponent implements OnInit, OnDestroy {
   @ViewChild('container', { static: true }) container!: ElementRef;
-  @HostBinding('@osdFabState')
+  @HostBinding('@osdComponentState')
   get osdFabState() {
     return this.state;
   }
@@ -95,8 +48,8 @@ export class OsdToolbarComponent implements OnInit, OnDestroy {
   isWeb = false;
   fabState = 'closed';
   fabIcon = 'menu';
-  showControls = false;
-  baseDelay = 20;
+  showControlButtons = false;
+  baseAnimationDelay = 20;
   isZoomed = true;
   private subscriptions = new Subscription();
 
@@ -156,7 +109,7 @@ export class OsdToolbarComponent implements OnInit, OnDestroy {
   }
 
   onFabClick(): void {
-    this.showControls = !this.showControls;
+    this.showControlButtons = !this.showControlButtons;
     this.fabState = this.fabState === 'closed' ? 'open' : 'closed';
     this.fabIcon = this.fabState === 'closed' ? 'menu' : 'clear';
   }

--- a/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/osd-toolbar/osd-toolbar.component.ts
@@ -60,11 +60,11 @@ import { ViewerService } from './../../core/viewer-service/viewer.service';
       ),
     ]),
     trigger('fabOpenState', [
-      transition('menu => clear', [
+      transition('closed => open', [
         style({ transform: 'rotate(-45deg)', opacity: 0 }),
         animate('200ms')
       ]),
-      transition('clear => menu', [
+      transition('open => closed', [
         style({ transform: 'rotate(45deg)', opacity: 0 }),
         animate('200ms')
       ]),
@@ -92,7 +92,8 @@ export class OsdToolbarComponent implements OnInit, OnDestroy {
   public state = 'hide';
   invert = false;
   isWeb = false;
-  fabOpenState = 'menu';
+  fabState = 'closed';
+  fabIcon = 'menu';
   showControls = false;
   baseDelay = 20;
   private subscriptions = new Subscription();
@@ -146,7 +147,8 @@ export class OsdToolbarComponent implements OnInit, OnDestroy {
 
   onFabClick(): void {
     this.showControls = !this.showControls;
-    this.fabOpenState = this.fabOpenState === 'menu' ? 'clear' : 'menu';
+    this.fabState = this.fabState === 'closed' ? 'open' : 'closed';
+    this.fabIcon = this.fabState === 'closed' ? 'menu' : 'clear';
   }
 
   zoomIn(): void {

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.html
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.html
@@ -12,7 +12,7 @@
   ></mime-viewer-header>
   <mime-osd-toolbar
     *ngIf="config?.navigationControlEnabled"
-    #mimeOsdToolbar
+    [@slideInLeft]="osdToolbarState"
   ></mime-osd-toolbar>
 
   <mat-drawer-container class="viewer-drawer-container" autosize>

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.spec.ts
@@ -500,8 +500,8 @@ describe('ViewerComponent', function () {
         testHostFixture.detectChanges();
         testHostFixture.whenStable().then(() => {
           expectOsdToolbarToBeHidden();
+          done();
         });
-        done();
       }, osdAnimationTime);
     });
 
@@ -509,16 +509,17 @@ describe('ViewerComponent', function () {
       setTimeout(() => {
         comp.osdToolbarState = 'hide';
         testHostFixture.detectChanges();
+
         testHostFixture.whenStable().then(() => {
           expectOsdToolbarToBeHidden();
-        });
 
-        comp.osdToolbarState = 'show';
-        testHostFixture.detectChanges();
-        testHostFixture.whenStable().then(() => {
-          expectOsdToolbarToBeVisible();
+          comp.osdToolbarState = 'show';
+          testHostFixture.detectChanges();
+          testHostFixture.whenStable().then(() => {
+            expectOsdToolbarToBeVisible();
+          });
+          done();
         });
-        done();
       }, osdAnimationTime);
     });
   });

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.spec.ts
@@ -491,6 +491,50 @@ describe('ViewerComponent', function () {
     });
   });
 
+  describe('Fab button for toggling OSD controls', () => {
+    it("should not be visible when state is changed to 'hide'", (done) => {
+      setTimeout(() => {
+        expectOsdToolbarToBeVisible();
+
+        comp.osdToolbarState = 'hide';
+        testHostFixture.detectChanges();
+        testHostFixture.whenStable().then(() => {
+          expectOsdToolbarToBeHidden();
+        });
+        done();
+      }, osdAnimationTime);
+    });
+
+    it("should be visible when state is changed to 'show'", (done) => {
+      setTimeout(() => {
+        comp.osdToolbarState = 'hide';
+        testHostFixture.detectChanges();
+        testHostFixture.whenStable().then(() => {
+          expectOsdToolbarToBeHidden();
+        });
+
+        comp.osdToolbarState = 'show';
+        testHostFixture.detectChanges();
+        testHostFixture.whenStable().then(() => {
+          expectOsdToolbarToBeVisible();
+        });
+        done();
+      }, osdAnimationTime);
+    });
+  });
+
+  const expectOsdToolbarToBeVisible = () => {
+    expect(getOsdToolbar().style.transform).toBe('translate(0px, 0px)');
+  };
+
+  const expectOsdToolbarToBeHidden = () => {
+    expect(getOsdToolbar().style.transform).toBe('translate(-100%, 0px)');
+  };
+
+  const getOsdToolbar = () => {
+    return testHostFixture.debugElement.query(By.css('mime-osd-toolbar')).nativeElement;
+  }
+
   function pinchOut() {
     viewerService
       .getViewer()

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.spec.ts
@@ -532,8 +532,9 @@ describe('ViewerComponent', function () {
   };
 
   const getOsdToolbar = () => {
-    return testHostFixture.debugElement.query(By.css('mime-osd-toolbar')).nativeElement;
-  }
+    return testHostFixture.debugElement.query(By.css('mime-osd-toolbar'))
+      .nativeElement;
+  };
 
   function pinchOut() {
     viewerService

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.ts
@@ -17,7 +17,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Subscription, interval } from 'rxjs';
+import { interval, Subscription } from 'rxjs';
 import { take, throttle } from 'rxjs/operators';
 import { AttributionDialogService } from '../attribution-dialog/attribution-dialog.service';
 import { CanvasGroupDialogService } from '../canvas-group-dialog/canvas-group-dialog.service';
@@ -49,15 +49,16 @@ import { InformationDialogService } from '../information-dialog/information-dial
 import { ViewDialogService } from '../view-dialog/view-dialog.service';
 import { IiifContentSearchService } from './../core/iiif-content-search-service/iiif-content-search.service';
 import { SearchResult } from './../core/models/search-result';
-import { OsdToolbarComponent } from './osd-toolbar/osd-toolbar.component';
 import { ViewerFooterComponent } from './viewer-footer/viewer-footer.component';
 import { ViewerHeaderComponent } from './viewer-header/viewer-header.component';
 import { VIEWER_PROVIDERS } from './viewer.providers';
+import { slideInLeft } from './osd-toolbar/animations';
 
 @Component({
   selector: 'mime-viewer',
   templateUrl: './viewer.component.html',
   styleUrls: ['./viewer.component.scss'],
+  animations: [slideInLeft],
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: VIEWER_PROVIDERS,
 })
@@ -86,6 +87,7 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
 
   recognizedTextContentMode: RecognizedTextMode = RecognizedTextMode.NONE;
   showHeaderAndFooterState = 'hide';
+  osdToolbarState = 'hide';
   public errorMessage: string | null = null;
 
   // Viewchilds
@@ -93,8 +95,6 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
   private header!: ViewerHeaderComponent;
   @ViewChild('mimeFooter', { static: true })
   private footer!: ViewerFooterComponent;
-  @ViewChild('mimeOsdToolbar')
-  private osdToolbar!: OsdToolbarComponent;
 
   constructor(
     public snackBar: MatSnackBar,
@@ -427,8 +427,8 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
             this.header.state =
             this.footer.state =
               'show';
-          if (this.config.navigationControlEnabled && this.osdToolbar) {
-            this.osdToolbar.state = 'hide';
+          if (this.config.navigationControlEnabled && this.osdToolbarState) {
+            this.osdToolbarState = 'hide';
           }
           break;
         case ViewerMode.PAGE:
@@ -436,8 +436,8 @@ export class ViewerComponent implements OnInit, OnDestroy, OnChanges {
             this.header.state =
             this.footer.state =
               'hide';
-          if (this.config.navigationControlEnabled && this.osdToolbar) {
-            this.osdToolbar.state = 'show';
+          if (this.config.navigationControlEnabled && this.osdToolbarState) {
+            this.osdToolbarState = 'show';
           }
           break;
       }

--- a/libs/ngx-mime/src/lib/viewer/viewer.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer.component.ts
@@ -52,7 +52,7 @@ import { SearchResult } from './../core/models/search-result';
 import { ViewerFooterComponent } from './viewer-footer/viewer-footer.component';
 import { ViewerHeaderComponent } from './viewer-header/viewer-header.component';
 import { VIEWER_PROVIDERS } from './viewer.providers';
-import { slideInLeft } from './osd-toolbar/animations';
+import { slideInLeft } from './../shared/animations';
 
 @Component({
   selector: 'mime-viewer',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The OSD toolbar was in some cases blocking or disturbing the readability of text in objects, especially when zoomed in or when using browser zoom.

Issue Number: N/A

## What is the new behavior?
The OSD toolbar is replaced with a FAB button and the control buttons are not initially shown. This makes the OSD toolbar cover a much less area than before.
The OSD control buttons can be toggled on and off with this new FAB button.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
The OSD toolbar also now uses colors from selected theme.
The order of the OSD control buttons are also slightly changed. The "Zoom Home" button now sits between "Zoom In" and "Zoom Out" button so that zoom buttons are grouped together. Before the "Zoom Home" button was placed between the navigation buttons and could be confused with the ability to navigate back to the first page.