### PR TITLE
fix(ngx-mime): change default drawer type to CANVAS

### DIFF
--- a/libs/ngx-mime/src/lib/core/viewer-service/drawer-utils.spec.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/drawer-utils.spec.ts
@@ -11,8 +11,8 @@ const RENDERER_CASES: [string, () => void, DrawerType][] = [
   ['iOS device (userAgent)', mockIOS, DrawerType.HTML],
   ['iOS via MacIntel + touch', mockMacTouch, DrawerType.HTML],
   ['macOS desktop (no touch)', mockMacDesktop, DrawerType.CANVAS],
-  ['Linux platform', mockLinux, DrawerType.WEBGL],
-  ['Windows platform', mockWindows, DrawerType.WEBGL],
+  ['Linux platform', mockLinux, DrawerType.CANVAS],
+  ['Windows platform', mockWindows, DrawerType.CANVAS],
 ];
 
 describe('drawer-utils', () => {

--- a/libs/ngx-mime/src/lib/core/viewer-service/drawer-utils.ts
+++ b/libs/ngx-mime/src/lib/core/viewer-service/drawer-utils.ts
@@ -15,7 +15,9 @@ export function getDrawerType(): DrawerType {
   } else if (isMacDesktop(platform, touch)) {
     return DrawerType.CANVAS;
   } else {
-    return DrawerType.WEBGL;
+    // Temporary workaround: force Canvas rendering until OpenSeadragon has full WebGL support.
+    // See: https://github.com/openseadragon/openseadragon/issues/2604
+    return DrawerType.CANVAS;
   }
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Temporary workaround: force Canvas rendering until OpenSeadragon has full WebGL support.
See: https://github.com/openseadragon/openseadragon/issues/2604


## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
