### PR TITLE
build(release): allow dist artifacts to be staged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
-# compiled output
-/dist
+# compiled output; release artifacts remain trackable
+/dist/**
+!/dist/**/
+!/dist/apps/elements/**
+!/dist/libs/@nationallibraryofnorway/ngx-mime/**
+
 /tmp
 /out-tsc
 

--- a/libs/ngx-mime/project.json
+++ b/libs/ngx-mime/project.json
@@ -34,7 +34,7 @@
       "defaultConfiguration": "production"
     },
     "prepare-release": {
-      "command": "if [ \"$NX_DRY_RUN\" != \"true\" ]; then git add -f dist/apps/elements dist/libs/@nationallibraryofnorway/ngx-mime; fi",
+      "command": "if [ \"$NX_DRY_RUN\" != \"true\" ]; then git add dist/apps/elements dist/libs/@nationallibraryofnorway/ngx-mime; fi",
       "dependsOn": [
         {
           "projects": ["ngx-mime", "elements"],

--- a/nx.json
+++ b/nx.json
@@ -97,7 +97,7 @@
     "projects": ["ngx-mime"],
     "version": {
       "conventionalCommits": true,
-      "preVersionCommand": "if [ \"$NX_DRY_RUN\" = \"true\" ]; then echo \"Skipping release build during dry run\"; else npx nx run ngx-mime:prepare-release --configuration=production; fi"
+      "preVersionCommand": "if [ \"$NX_DRY_RUN\" = \"true\" ]; then echo \"Skipping release build during dry run\"; else yarn nx run ngx-mime:prepare-release --configuration=production; fi"
     },
     "git": {
       "commitMessage": "chore(release): {version}"


### PR DESCRIPTION
- Keep general build output ignored while allowing release artifacts.
- Track the custom-elements and publishable library distributions.
- Stage release files without forcing ignored paths.
- Use the workspace Yarn Nx CLI for the pre-version build.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NationalLibraryOfNorway/ngx-mime/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
